### PR TITLE
fix: resolve QA bugs from TestFlight build 4.1.0 + animation token system

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -78,7 +78,7 @@
     "staging": {
       "extends": "production",
       "cache": {
-        "key": "sdk55-staging-v1"
+        "key": "sdk55-staging-v2"
       },
       "env": {
         "ENVIRONMENT": "prod",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@reduxjs/toolkit": "^2.5.1",
     "@ronradtke/react-native-markdown-display": "^8.1.0",
     "@sentry/react-native": "^7.11.0",
-    "@shopify/flash-list": "^2.0.2",
+    "@shopify/flash-list": "^2.3.0",
     "ai": "5.0.93",
     "axios": "^1.13.6",
     "camelcase": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "expo-font": "~55.0.4",
     "expo-haptics": "~55.0.8",
     "expo-image": "~55.0.6",
+    "expo-image-manipulator": "^55.0.9",
     "expo-image-picker": "~55.0.11",
     "expo-linking": "~55.0.7",
     "expo-localization": "~55.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,8 +87,8 @@ importers:
         specifier: ^7.11.0
         version: 7.11.0(expo@55.0.5(@babel/core@7.28.4)(@expo/dom-webview@55.0.3)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.28.4)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.4)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3))(react-native@0.83.2(@babel/core@7.28.4)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       '@shopify/flash-list':
-        specifier: ^2.0.2
-        version: 2.0.2(@babel/runtime@7.27.1)(react-native@0.83.2(@babel/core@7.28.4)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+        specifier: ^2.3.0
+        version: 2.3.0(@babel/runtime@7.27.1)(react-native@0.83.2(@babel/core@7.28.4)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       ai:
         specifier: 5.0.93
         version: 5.0.93(zod@4.1.13)
@@ -2330,8 +2330,8 @@ packages:
     resolution: {integrity: sha512-umpnUKRC0AAbJrADg6SlFtqN2yzf7NHciCF9lkHau+ax2PIZ/NDmoG4RQujFVflVaVoD60Ly2t+CcPnYIWMPlw==}
     engines: {node: '>=18'}
 
-  '@shopify/flash-list@2.0.2':
-    resolution: {integrity: sha512-zhlrhA9eiuEzja4wxVvotgXHtqd3qsYbXkQ3rsBfOgbFA9BVeErpDE/yEwtlIviRGEqpuFj/oU5owD6ByaNX+w==}
+  '@shopify/flash-list@2.3.0':
+    resolution: {integrity: sha512-DR7VuN8KJHTYj9zv1/IhpqrMBMQyeeW/DCWCbVQAAkWhHrc6ylIbXOY+qK93CuHABV+dNHXK/3V6p4wCSW/+wA==}
     peerDependencies:
       '@babel/runtime': '*'
       react: 19.2.0
@@ -9023,12 +9023,11 @@ snapshots:
     dependencies:
       '@sentry/core': 10.37.0
 
-  '@shopify/flash-list@2.0.2(@babel/runtime@7.27.1)(react-native@0.83.2(@babel/core@7.28.4)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)':
+  '@shopify/flash-list@2.3.0(@babel/runtime@7.27.1)(react-native@0.83.2(@babel/core@7.28.4)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.27.1
       react: 19.2.0
       react-native: 0.83.2(@babel/core@7.28.4)(@types/react@19.2.14)(react@19.2.0)
-      tslib: 2.8.1
 
   '@sinclair/typebox@0.27.8': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       expo-image:
         specifier: ~55.0.6
         version: 55.0.6(expo@55.0.5(@babel/core@7.28.4)(@expo/dom-webview@55.0.3)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.28.4)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.4)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3))(react-native@0.83.2(@babel/core@7.28.4)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+      expo-image-manipulator:
+        specifier: ^55.0.9
+        version: 55.0.9(expo@55.0.5(@babel/core@7.28.4)(@expo/dom-webview@55.0.3)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.28.4)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.4)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3))
       expo-image-picker:
         specifier: ~55.0.11
         version: 55.0.11(expo@55.0.5(@babel/core@7.28.4)(@expo/dom-webview@55.0.3)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.28.4)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.4)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3))
@@ -3810,6 +3813,11 @@ packages:
 
   expo-image-loader@55.0.0:
     resolution: {integrity: sha512-NOjp56wDrfuA5aiNAybBIjqIn1IxKeGJ8CECWZncQ/GzjZfyTYAHTCyeApYkdKkMBLHINzI4BbTGSlbCa0fXXQ==}
+    peerDependencies:
+      expo: '*'
+
+  expo-image-manipulator@55.0.9:
+    resolution: {integrity: sha512-hEponYwRHwYlmYn2KTVr57U6i7dJ4NI6gYUT6LwxxLFspiev+ntlXL0e6M7qT0VIHMkLPtBcvP/z3+vaJCNgeQ==}
     peerDependencies:
       expo: '*'
 
@@ -10910,6 +10918,11 @@ snapshots:
   expo-image-loader@55.0.0(expo@55.0.5(@babel/core@7.28.4)(@expo/dom-webview@55.0.3)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.28.4)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.4)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)):
     dependencies:
       expo: 55.0.5(@babel/core@7.28.4)(@expo/dom-webview@55.0.3)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.28.4)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.4)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+
+  expo-image-manipulator@55.0.9(expo@55.0.5(@babel/core@7.28.4)(@expo/dom-webview@55.0.3)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.28.4)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.4)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)):
+    dependencies:
+      expo: 55.0.5(@babel/core@7.28.4)(@expo/dom-webview@55.0.3)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.28.4)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.4)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      expo-image-loader: 55.0.0(expo@55.0.5(@babel/core@7.28.4)(@expo/dom-webview@55.0.3)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.28.4)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.4)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3))
 
   expo-image-picker@55.0.11(expo@55.0.5(@babel/core@7.28.4)(@expo/dom-webview@55.0.3)(react-dom@19.2.0(react@19.2.0))(react-native-webview@13.16.1(react-native@0.83.2(@babel/core@7.28.4)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.4)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)):
     dependencies:

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -64,6 +64,25 @@ jest.mock('@react-navigation/native', () => ({
 
 // ─── Native Module Mocks ────────────────────────────────────────
 jest.mock('react-native-reanimated', () => {
+  // Chainable builder mock — each method returns a new object (fresh instance per call)
+  const createAnimationBuilder = () => {
+    const makeChainable = (): Record<string, any> => {
+      const builder: Record<string, any> = {};
+      const chainable = (..._args: any[]) => makeChainable();
+      builder.springify = chainable;
+      builder.damping = chainable;
+      builder.stiffness = chainable;
+      builder.mass = chainable;
+      builder.duration = chainable;
+      builder.easing = chainable;
+      builder.delay = chainable;
+      builder.withInitialValues = chainable;
+      builder.build = chainable;
+      return builder;
+    };
+    return makeChainable();
+  };
+
   return {
     default: {
       View: 'Animated.View',
@@ -87,7 +106,20 @@ jest.mock('react-native-reanimated', () => {
       in: jest.fn(),
       out: jest.fn(),
       inOut: jest.fn(),
+      bezier: jest.fn(() => ({ factory: jest.fn() })),
     },
+    // Layout animation builders
+    LinearTransition: createAnimationBuilder(),
+    SlideInDown: createAnimationBuilder(),
+    SlideInUp: createAnimationBuilder(),
+    SlideOutDown: createAnimationBuilder(),
+    SlideOutUp: createAnimationBuilder(),
+    SlideInRight: createAnimationBuilder(),
+    SlideInLeft: createAnimationBuilder(),
+    SlideOutRight: createAnimationBuilder(),
+    SlideOutLeft: createAnimationBuilder(),
+    FadeIn: createAnimationBuilder(),
+    FadeOut: createAnimationBuilder(),
   };
 });
 

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -4,7 +4,7 @@
  * This file configures the test environment with global mocks,
  * console suppression, and test utilities for ALL test suites.
  */
-/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-require-imports, @typescript-eslint/no-unused-vars, @typescript-eslint/no-namespace */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
 import 'reflect-metadata';
 
@@ -140,6 +140,36 @@ jest.mock('@react-native-documents/picker', () => ({
   isErrorWithCode: jest.fn(() => false),
   errorCodes: { OPERATION_CANCELED: 'OPERATION_CANCELED' },
 }));
+
+jest.mock('expo-image-manipulator', () => ({
+  ImageManipulator: {
+    manipulate: jest.fn(() => ({
+      rotate: jest.fn().mockReturnThis(),
+      renderAsync: jest.fn(() =>
+        Promise.resolve({
+          width: 100,
+          height: 100,
+          saveAsync: jest.fn(() =>
+            Promise.resolve({ uri: 'file://converted.jpg', width: 100, height: 100 }),
+          ),
+        }),
+      ),
+    })),
+  },
+  SaveFormat: { JPEG: 'jpeg', PNG: 'png', WEBP: 'webp' },
+}));
+
+jest.mock('expo-file-system', () => {
+  class MockFile {
+    uri: string;
+    exists = true;
+    size = 1024;
+    constructor(uri: string) {
+      this.uri = uri;
+    }
+  }
+  return { File: MockFile, Directory: jest.fn(), Paths: { cache: '', document: '' } };
+});
 
 jest.mock('expo-haptics', () => ({
   impactAsync: jest.fn(),

--- a/src/application/navigation/index.tsx
+++ b/src/application/navigation/index.tsx
@@ -1,25 +1,27 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 import React, { useCallback, useRef, useEffect } from 'react';
 import { ActivityIndicator, Linking, StyleSheet, View } from 'react-native';
-import { getApps } from '@react-native-firebase/app';
-import { getApp } from '@react-native-firebase/app';
+import { getApps, getApp } from '@react-native-firebase/app';
 import {
   getMessaging,
   setBackgroundMessageHandler,
   onNotificationOpenedApp,
   getInitialNotification,
 } from '@react-native-firebase/messaging';
-import { getStateFromPath } from '@react-navigation/native';
+import {
+  getStateFromPath,
+  NavigationContainer,
+  DefaultTheme,
+  DarkTheme,
+} from '@react-navigation/native';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
 import { useFonts } from 'expo-font';
 import * as SplashScreen from 'expo-splash-screen';
 
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
-import { NavigationContainer, DefaultTheme, DarkTheme } from '@react-navigation/native';
 import { AppTabs } from './tabs/AppTabs';
 import i18n from '@infrastructure/i18n';
 import { navigationRef } from '@infrastructure/utils/navigationUtils';
-import { useTheme } from '@infrastructure/context';
+import { useTheme, RefsProvider } from '@infrastructure/context';
 import {
   findConversationLinkFromPush,
   findNotificationFromFCM,
@@ -27,16 +29,14 @@ import {
 } from '@infrastructure/utils/pushUtils';
 import { extractConversationIdFromUrl } from '@infrastructure/utils/conversationUtils';
 import { tailwind } from '@infrastructure/theme';
-import { useAppSelector, useThemedStyles } from '@/hooks';
+import { useAppSelector, useThemedStyles, useAppDispatch } from '@/hooks';
 import { selectInstallationUrl, selectLocale } from '@application/store/settings/settingsSelectors';
 import { SSO_CALLBACK_URL } from '@domain/constants';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
-import { RefsProvider } from '@infrastructure/context';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import { waitForFirebaseInit } from '@infrastructure/utils/firebaseUtils';
+import { isFirebaseInitialized, waitForFirebaseInit } from '@infrastructure/utils/firebaseUtils';
 import { transformNotification } from '@infrastructure/utils/camelCaseKeys';
 import { SsoUtils } from '@infrastructure/utils/ssoUtils';
-import { useAppDispatch } from '@/hooks';
 import Inter40020 from '@/assets/fonts/Inter-400-20.ttf';
 import Inter42020 from '@/assets/fonts/Inter-420-20.ttf';
 import Inter50024 from '@/assets/fonts/Inter-500-24.ttf';
@@ -46,14 +46,10 @@ import Inter60020 from '@/assets/fonts/Inter-600-20.ttf';
 // Initialize Firebase messaging handlers after app starts
 const initializeFirebaseMessaging = () => {
   try {
-    // Ensure Firebase is initialized (should be auto-initialized by plugin, but let's be explicit)
-    const apps = getApps();
-    if (!apps.length) {
-      console.warn('Firebase not initialized, skipping messaging setup...');
+    if (!isFirebaseInitialized()) {
+      console.warn('[Firebase] Not initialized — skipping messaging setup');
       return;
     }
-
-    console.warn('Firebase already initialized, setting up messaging...');
 
     const messaging = getMessaging(getApp());
     setBackgroundMessageHandler(messaging, async remoteMessage => {
@@ -229,6 +225,10 @@ export const AppNavigationContainer = () => {
       }
 
       // getInitialNotification: When the application is opened from a quit state.
+      if (!isFirebaseInitialized()) {
+        console.warn('[Firebase] Not initialized — skipping getInitialNotification');
+        return undefined;
+      }
       const messaging = getMessaging(getApp());
       const message = await getInitialNotification(messaging);
       if (message) {

--- a/src/application/navigation/tabs/ActionBottomSheet.tsx
+++ b/src/application/navigation/tabs/ActionBottomSheet.tsx
@@ -2,14 +2,13 @@ import React, { useMemo } from 'react';
 import { BottomSheetModal, useBottomSheetSpringConfigs } from '@gorhom/bottom-sheet';
 import { tailwind } from '@infrastructure/theme';
 import { BottomSheetBackdrop } from '@infrastructure/ui';
-import { useAppDispatch, useAppSelector } from '@/hooks';
+import { useAppDispatch, useAppSelector, useThemedStyles } from '@/hooks';
 import {
   resetActionState,
   selectCurrentActionState,
 } from '@application/store/conversation/conversationActionSlice';
 
 import { useRefsContext } from '@infrastructure/context';
-import { useThemedStyles } from '@/hooks';
 import {
   UpdateAssignee,
   UpdateStatus,
@@ -26,7 +25,7 @@ const ActionBottomSheet = () => {
   const animationConfigs = useBottomSheetSpringConfigs({
     mass: 1,
     stiffness: 420,
-    damping: 30,
+    damping: 80,
   });
 
   const { actionsModalSheetRef } = useRefsContext();

--- a/src/application/navigation/tabs/ActionBottomSheet.tsx
+++ b/src/application/navigation/tabs/ActionBottomSheet.tsx
@@ -23,12 +23,6 @@ const ActionBottomSheet = () => {
   const currentActionState = useAppSelector(selectCurrentActionState);
   const themedTailwind = useThemedStyles();
 
-  const animationConfigs = useBottomSheetSpringConfigs({
-    mass: 1,
-    stiffness: 420,
-    damping: 80,
-  });
-
   const { actionsModalSheetRef } = useRefsContext();
 
   const actionSnapPoints = useMemo(() => {
@@ -60,7 +54,7 @@ const ActionBottomSheet = () => {
       handleStyle={tailwind.style('p-0 h-4 pt-[5px]')}
       style={tailwind.style('rounded-[26px] overflow-hidden')}
       backgroundStyle={themedTailwind.style('bg-solid-1')}
-      animationConfigs={animationConfigs}
+      animationConfigs={spring.sheet}
       enablePanDownToClose
       snapPoints={actionSnapPoints}
       onDismiss={handleOnDismiss}>

--- a/src/application/navigation/tabs/ActionBottomSheet.tsx
+++ b/src/application/navigation/tabs/ActionBottomSheet.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
-import { BottomSheetModal, useBottomSheetSpringConfigs } from '@gorhom/bottom-sheet';
+import { BottomSheetModal } from '@gorhom/bottom-sheet';
+import { spring } from '@infrastructure/animation';
 import { tailwind } from '@infrastructure/theme';
 import { BottomSheetBackdrop } from '@infrastructure/ui';
 import { useAppDispatch, useAppSelector, useThemedStyles } from '@/hooks';

--- a/src/application/navigation/tabs/BottomTabBar.tsx
+++ b/src/application/navigation/tabs/BottomTabBar.tsx
@@ -11,6 +11,7 @@ import { BottomTabBarProps } from '@react-navigation/bottom-tabs';
 import { RouteProp } from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { selectCurrentState } from '@application/store/conversation/conversationHeaderSlice';
+import { spring } from '@infrastructure/animation';
 
 import {
   ConversationIconFilled,
@@ -28,9 +29,6 @@ import { useAppSelector, useThemedStyles } from '@/hooks';
 import { useTheme } from '@infrastructure/context';
 
 const AnimatedBlurView = Animated.createAnimatedComponent(BlurView);
-
-const tabExitSpringConfig = { damping: 28, stiffness: 360, mass: 1 };
-const tabEnterSpringConfig = { damping: 30, stiffness: 360, mass: 1 };
 
 type TabBarIconsProps = {
   focused: boolean;
@@ -76,9 +74,7 @@ const TabBarBackground = (props: TabBarBackgroundProps) => {
   const tabBarHeight = useTabBarHeight();
 
   const derivedAnimatedState = useDerivedValue(() =>
-    currentState === 'Select'
-      ? withSpring(1, tabExitSpringConfig)
-      : withSpring(0, tabEnterSpringConfig),
+    currentState === 'Select' ? withSpring(1, spring.tabExit) : withSpring(0, spring.tabEnter),
   );
 
   const animatedTabBarStyle = useAnimatedStyle(() => {

--- a/src/application/navigation/tabs/BottomTabBar.tsx
+++ b/src/application/navigation/tabs/BottomTabBar.tsx
@@ -38,11 +38,11 @@ type TabBarIconsProps = {
 };
 
 const TabBarIcons = ({ focused, route }: TabBarIconsProps) => {
-  const { semanticColors } = useThemeColors();
+  const { colors, semanticColors } = useThemeColors();
 
-  // Focused: Use primary brand color (iris-9 purple in both modes)
-  // Unfocused: Use muted text color (slate-10)
-  const iconColor = focused ? semanticColors.primary : semanticColors.textMuted;
+  // Active: iris-11 provides high-contrast brand tint in both light/dark modes
+  // Inactive: textSecondary (slate-11) provides readable contrast, matching web sidebar
+  const iconColor = focused ? colors.iris[11] : semanticColors.textSecondary;
 
   switch (route.name) {
     case 'Conversations':

--- a/src/application/navigation/tabs/BottomTabBar.tsx
+++ b/src/application/navigation/tabs/BottomTabBar.tsx
@@ -9,6 +9,7 @@ import Animated, {
 import { BlurView, BlurViewProps } from 'expo-blur';
 import { BottomTabBarProps } from '@react-navigation/bottom-tabs';
 import { RouteProp } from '@react-navigation/native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { selectCurrentState } from '@application/store/conversation/conversationHeaderSlice';
 
 import {
@@ -136,6 +137,7 @@ export const BottomTabBar = ({ state, descriptors, navigation }: BottomTabBarPro
   const tabBarHeight = useTabBarHeight();
   const { isDark } = useTheme();
   const themedTailwind = useThemedStyles();
+  const { bottom } = useSafeAreaInsets();
 
   // Memoize press handlers using useCallback
   const createPressHandler = React.useCallback(
@@ -176,13 +178,13 @@ export const BottomTabBar = ({ state, descriptors, navigation }: BottomTabBarPro
       style={Platform.select({
         ios: [
           themedTailwind.style(
-            'flex flex-row absolute w-full bottom-0 pl-[72px] pr-[71px] pt-[11px] pb-8 bg-solid-1',
+            `flex flex-row absolute w-full bottom-0 pl-[72px] pr-[71px] pt-[11px] pb-[${Math.max(bottom, 32)}px] bg-solid-1`,
             `h-[${tabBarHeight}px]`,
           ),
         ],
         android: [
           themedTailwind.style(
-            'flex flex-row absolute w-full bottom-0 pl-[72px] pr-[71px] py-[11px] bg-solid-1',
+            `flex flex-row absolute w-full bottom-0 pl-[72px] pr-[71px] pt-[11px] pb-[${Math.max(bottom, 11)}px] bg-solid-1`,
             `h-[${tabBarHeight}px]`,
           ),
         ],

--- a/src/application/navigation/tabs/BottomTabBar.tsx
+++ b/src/application/navigation/tabs/BottomTabBar.tsx
@@ -29,7 +29,7 @@ import { useTheme } from '@infrastructure/context';
 
 const AnimatedBlurView = Animated.createAnimatedComponent(BlurView);
 
-const tabExitSpringConfig = { damping: 20, stiffness: 360, mass: 1 };
+const tabExitSpringConfig = { damping: 28, stiffness: 360, mass: 1 };
 const tabEnterSpringConfig = { damping: 30, stiffness: 360, mass: 1 };
 
 type TabBarIconsProps = {

--- a/src/application/store/conversation/__tests__/conversationActions.test.ts
+++ b/src/application/store/conversation/__tests__/conversationActions.test.ts
@@ -294,6 +294,26 @@ describe('conversationActions', () => {
       expect(lastMessage.status).toBe(MESSAGE_STATUS.FAILED);
     });
 
+    it('should use multipart/form-data Content-Type when file is present in payload', async () => {
+      const filePayload = makeSendMessagePayload({
+        file: { uri: 'file://photo.jpg', fileName: 'photo.jpg', type: 'image/jpeg' },
+      });
+      const pendingMsg = makePendingMessage(filePayload);
+      const builtPayload = { content: 'Hello world', private: false, echo_id: 'temp-uuid-123' };
+      mockCreatePendingMessage.mockReturnValue(pendingMsg);
+      mockBuildCreatePayload.mockReturnValue(builtPayload);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mockService.sendMessage.mockResolvedValue(makeApiResponse() as any);
+
+      const store = createStore();
+      await store.dispatch(conversationActions.sendMessage(filePayload));
+
+      // Content-Type should be 'multipart/form-data', NOT the file's MIME type ('image/jpeg')
+      expect(mockService.sendMessage).toHaveBeenCalledWith(1, builtPayload, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      });
+    });
+
     it('should result in a failed message and throw when error has no response (network error)', async () => {
       const pendingMsg = makePendingMessage(sendPayload);
       mockCreatePendingMessage.mockReturnValue(pendingMsg);

--- a/src/application/store/conversation/__tests__/conversationSlice.test.ts
+++ b/src/application/store/conversation/__tests__/conversationSlice.test.ts
@@ -211,7 +211,7 @@ describe('conversationSlice', () => {
       expect(state).toEqual(initialState);
     });
 
-    it('should append message when same ID exists but findPendingMessageIndex returns -1', () => {
+    it('should update in-place when same numeric ID exists but findPendingMessageIndex returns -1', () => {
       const existingMessage = aMessage()
         .withId(10)
         .withConversationId(1)
@@ -228,8 +228,33 @@ describe('conversationSlice', () => {
 
       const state = reducer(initialState, addOrUpdateMessage(duplicateMessage));
 
-      // When findPendingMessageIndex returns -1, the message is appended (even if same ID)
+      // Numeric ID dedup should prevent a duplicate; the existing message is updated in-place
+      expect(state.entities[1]?.messages).toHaveLength(1);
+      expect(state.entities[1]?.messages[0].status).toBe('delivered');
+    });
+
+    it('should push message when ID is a string (pending message)', () => {
+      const existingMessage = aMessage()
+        .withId(10)
+        .withConversationId(1)
+        .withStatus('sent')
+        .build();
+      const conversation = aConversation().withId(1).withMessages([existingMessage]).build();
+      const initialState = stateWithConversation(conversation);
+      // Pending messages have string IDs (echoIds) — they should still be pushed normally
+      const pendingMessage = {
+        ...aMessage().withConversationId(1).withStatus('progress').build(),
+        id: 'temp-uuid-456' as unknown as number,
+        echoId: 'temp-uuid-456',
+      };
+      mockFindPendingMessageIndex.mockReturnValue(-1);
+
+      const state = reducer(initialState, addOrUpdateMessage(pendingMessage));
+
+      // String ID should bypass the numeric dedup guard and push normally
       expect(state.entities[1]?.messages).toHaveLength(2);
+      expect(state.entities[1]?.messages[0]).toEqual(existingMessage);
+      expect(state.entities[1]?.messages[1].id).toBe('temp-uuid-456');
     });
   });
 

--- a/src/application/store/conversation/conversationActions.ts
+++ b/src/application/store/conversation/conversationActions.ts
@@ -31,7 +31,6 @@ import { AxiosError } from 'axios';
 import { MESSAGE_STATUS } from '@domain/constants';
 import { buildCreatePayload, createPendingMessage } from '@infrastructure/utils/messageUtils';
 import { transformMessage } from '@infrastructure/utils/camelCaseKeys';
-import { Platform } from 'react-native';
 
 export const conversationActions = {
   fetchConversations: createAsyncThunk<ConversationListResponse, ConversationPayload>(
@@ -92,12 +91,7 @@ export const conversationActions = {
         });
         const payload = buildCreatePayload(pendingMessage);
         const { file } = sendMessagePayload;
-        const contentType =
-          Platform.OS === 'ios' && file
-            ? file.type
-            : Platform.OS === 'android' && file
-              ? 'multipart/form-data'
-              : 'application/json';
+        const contentType = file ? 'multipart/form-data' : 'application/json';
 
         const response = await ConversationService.sendMessage(conversationId, payload, {
           headers: {

--- a/src/application/store/conversation/conversationSlice.ts
+++ b/src/application/store/conversation/conversationSlice.ts
@@ -86,7 +86,19 @@ const conversationSlice = createSlice({
       }
       // If the message is not present in the conversation, add it
       else {
-        conversation.messages.push(message as Message);
+        // Guard against duplicate numeric IDs (e.g., WebSocket message.created
+        // arriving after the API response already added the message)
+        const numericId = (message as Message).id;
+        if (typeof numericId === 'number') {
+          const existingIndex = conversation.messages.findIndex(m => m.id === numericId);
+          if (existingIndex !== -1) {
+            conversation.messages[existingIndex] = message as Message;
+          } else {
+            conversation.messages.push(message as Message);
+          }
+        } else {
+          conversation.messages.push(message as Message);
+        }
       }
       conversation.timestamp = message.createdAt;
       conversation.unreadCount = (message as Message).conversation?.unreadCount || 0;

--- a/src/application/store/settings/settingsActions.ts
+++ b/src/application/store/settings/settingsActions.ts
@@ -19,6 +19,7 @@ import { URL_TYPE } from '@domain/constants/url';
 import { checkValidUrl, extractDomain, handleApiError } from './settingsUtils';
 import { showToast } from '@infrastructure/utils/toastUtils';
 import { requestNotificationPermissions } from '@infrastructure/utils/permissionManager';
+import { isFirebaseInitialized } from '@infrastructure/utils/firebaseUtils';
 
 const createSettingsThunk = <TResponse, TPayload>(
   type: string,
@@ -85,6 +86,10 @@ export const settingsActions = {
     'settings/saveDeviceDetails',
     async (_, { rejectWithValue }) => {
       try {
+        if (!isFirebaseInitialized()) {
+          console.warn('[Firebase] Not initialized — skipping saveDeviceDetails');
+          return rejectWithValue('Firebase not initialized');
+        }
         const messaging = getMessaging(getApp());
         const permissionEnabled = await hasPermission(messaging);
         const deviceId =

--- a/src/infrastructure/animation/__tests__/animations.test.ts
+++ b/src/infrastructure/animation/__tests__/animations.test.ts
@@ -1,0 +1,83 @@
+import {
+  softLayout,
+  snappyLayout,
+  snappySlideInDown,
+  snappySlideOutDown,
+  snappySlideInUp,
+  contentFadeIn,
+  quickFadeIn,
+  slowFadeIn,
+  createSlideIn,
+  createLayoutTransition,
+} from '../animations';
+import { spring } from '../springs';
+
+describe('animation factories', () => {
+  describe('layout transitions', () => {
+    it('should return a new instance each call for softLayout', () => {
+      const a = softLayout();
+      const b = softLayout();
+      expect(a).not.toBe(b);
+    });
+
+    it('should return a new instance each call for snappyLayout', () => {
+      const a = snappyLayout();
+      const b = snappyLayout();
+      expect(a).not.toBe(b);
+    });
+  });
+
+  describe('slide animations', () => {
+    it('should return a new instance each call for snappySlideInDown', () => {
+      const a = snappySlideInDown();
+      const b = snappySlideInDown();
+      expect(a).not.toBe(b);
+    });
+
+    it('should return a new instance each call for snappySlideOutDown', () => {
+      const a = snappySlideOutDown();
+      const b = snappySlideOutDown();
+      expect(a).not.toBe(b);
+    });
+
+    it('should return a new instance each call for snappySlideInUp', () => {
+      const a = snappySlideInUp();
+      const b = snappySlideInUp();
+      expect(a).not.toBe(b);
+    });
+  });
+
+  describe('fade animations', () => {
+    it('should return a new instance each call for contentFadeIn', () => {
+      const a = contentFadeIn();
+      const b = contentFadeIn();
+      expect(a).not.toBe(b);
+    });
+
+    it('should return a new instance each call for quickFadeIn', () => {
+      const a = quickFadeIn();
+      const b = quickFadeIn();
+      expect(a).not.toBe(b);
+    });
+
+    it('should return a new instance each call for slowFadeIn', () => {
+      const a = slowFadeIn();
+      const b = slowFadeIn();
+      expect(a).not.toBe(b);
+    });
+  });
+
+  describe('generic factories', () => {
+    it('should return a new instance each call for createSlideIn', () => {
+      const a = createSlideIn('down');
+      const b = createSlideIn('down');
+      expect(a).not.toBe(b);
+    });
+
+    it('should return a new instance each call for createLayoutTransition', () => {
+      const a = createLayoutTransition(spring.soft);
+      const b = createLayoutTransition(spring.soft);
+      expect(a).not.toBe(b);
+    });
+  });
+});

--- a/src/infrastructure/animation/__tests__/springs.test.ts
+++ b/src/infrastructure/animation/__tests__/springs.test.ts
@@ -1,0 +1,46 @@
+import { spring, timing, PRESS_SCALE_VALUE } from '../springs';
+
+describe('spring tokens', () => {
+  it('should have expected values for soft spring', () => {
+    expect(spring.soft).toEqual({ damping: 28, stiffness: 200 });
+  });
+
+  it('should have expected values for snappy spring', () => {
+    expect(spring.snappy).toEqual({ damping: 80, stiffness: 240 });
+  });
+
+  it('should have expected values for sheet spring', () => {
+    expect(spring.sheet).toEqual({ mass: 1, stiffness: 420, damping: 80 });
+  });
+
+  it('should have overshootClamping on keyboard spring', () => {
+    expect(spring.keyboard.overshootClamping).toBe(true);
+  });
+
+  it('should have overshootClamping on pressScale spring', () => {
+    expect(spring.pressScale.overshootClamping).toBe(true);
+  });
+
+  it('should export all tokens as plain objects (worklet-safe)', () => {
+    Object.values(spring).forEach(config => {
+      expect(typeof config).toBe('object');
+      expect(config).not.toBeInstanceOf(Function);
+    });
+  });
+});
+
+describe('timing tokens', () => {
+  it('should have expected duration tiers', () => {
+    expect(timing.quick.duration).toBe(150);
+    expect(timing.fast.duration).toBe(200);
+    expect(timing.standard.duration).toBe(250);
+    expect(timing.content.duration).toBe(300);
+    expect(timing.slow.duration).toBe(350);
+  });
+});
+
+describe('PRESS_SCALE_VALUE', () => {
+  it('should be 0.96', () => {
+    expect(PRESS_SCALE_VALUE).toBe(0.96);
+  });
+});

--- a/src/infrastructure/animation/animations.ts
+++ b/src/infrastructure/animation/animations.ts
@@ -1,0 +1,166 @@
+import {
+  LinearTransition,
+  SlideInDown,
+  SlideInUp,
+  SlideInRight,
+  SlideInLeft,
+  SlideOutDown,
+  SlideOutUp,
+  SlideOutRight,
+  SlideOutLeft,
+  FadeIn,
+  FadeOut,
+  Easing,
+} from 'react-native-reanimated';
+import type { WorkletSpringConfig } from './springs';
+import { spring, timing } from './springs';
+
+// ═══════════════════════════════════════════════════════════════════
+// IMPORTANT: All exports are FACTORY FUNCTIONS, not singletons.
+//
+// Reanimated layout animation builders are mutable objects. Sharing a
+// single instance across components causes animation interference.
+// Each call returns a fresh builder instance.
+//
+// Usage: layout={softLayout()}  ← parentheses required
+// ═══════════════════════════════════════════════════════════════════
+
+// ─── Layout Transitions ─────────────────────────────────────────
+
+/** Soft layout transition (damping 28, stiffness 200). Most common. */
+export const softLayout = () =>
+  LinearTransition.springify().damping(spring.soft.damping).stiffness(spring.soft.stiffness);
+
+/** Snappy layout transition (damping 80, stiffness 240). Panels, reply box. */
+export const snappyLayout = () =>
+  LinearTransition.springify().damping(spring.snappy.damping).stiffness(spring.snappy.stiffness);
+
+// ─── Slide Animations (spring-based) ────────────────────────────
+
+/** Snappy slide-in from bottom. Attached media, command menus. */
+export const snappySlideInDown = () =>
+  SlideInDown.springify().damping(spring.snappy.damping).stiffness(spring.snappy.stiffness);
+
+/** Snappy slide-in from top. Attachment list. */
+export const snappySlideInUp = () =>
+  SlideInUp.springify().damping(spring.snappy.damping).stiffness(spring.snappy.stiffness);
+
+/** Snappy slide-out to bottom. Dismiss overlays, remove attached media. */
+export const snappySlideOutDown = () =>
+  SlideOutDown.springify().damping(spring.snappy.damping).stiffness(spring.snappy.stiffness);
+
+// ─── Fade Animations (timing-based) ────────────────────────────
+
+/** Quick fade in (150ms). Message appearing, spinner mount. */
+export const quickFadeIn = () => FadeIn.duration(timing.quick.duration);
+
+/** Fast fade in (200ms). Swipeable cells. */
+export const fastFadeIn = () => FadeIn.duration(timing.fast.duration);
+
+/** Standard fade in (250ms). Quote reply, code number, general content. */
+export const standardFadeIn = () => FadeIn.duration(timing.standard.duration);
+
+/** Standard fade out (250ms). Code number exit, general content dismiss. */
+export const standardFadeOut = () => FadeOut.duration(timing.standard.duration);
+
+/**
+ * Content fade in (300ms + Easing.ease).
+ * Media cells, file cells, location cells, audio cells.
+ */
+export const contentFadeIn = () => FadeIn.duration(timing.content.duration).easing(Easing.ease);
+
+/**
+ * Content fade out (300ms + Easing.ease).
+ * Video overlay dismiss.
+ */
+export const contentFadeOut = () => FadeOut.duration(timing.content.duration).easing(Easing.ease);
+
+/** Content fade in (300ms, no easing). MacroDetails, onboarding. */
+export const contentFadeInLinear = () => FadeIn.duration(timing.content.duration);
+
+/** Slow fade in (350ms). Text message cells, composed cells, email cells. */
+export const slowFadeIn = () => FadeIn.duration(timing.slow.duration);
+
+/** Near-instant fade out (10ms). Quote reply exit (intentionally abrupt). */
+export const instantFadeOut = () => FadeOut.duration(10);
+
+/** Fast fade out (200ms). Screen transition exits, onboarding. */
+export const fastFadeOut = () => FadeOut.duration(timing.fast.duration);
+
+// ─── Generic Factory Functions ──────────────────────────────────
+
+type SlideDirection = 'down' | 'up' | 'left' | 'right';
+
+const slideInMap = {
+  down: SlideInDown,
+  up: SlideInUp,
+  left: SlideInLeft,
+  right: SlideInRight,
+} as const;
+
+const slideOutMap = {
+  down: SlideOutDown,
+  up: SlideOutUp,
+  left: SlideOutLeft,
+  right: SlideOutRight,
+} as const;
+
+/**
+ * Create a springified slide-in animation from a direction + spring config.
+ * @example createSlideIn('down', spring.snappy)
+ */
+export const createSlideIn = (
+  direction: SlideDirection,
+  config: WorkletSpringConfig = spring.snappy,
+) => {
+  let animation = slideInMap[direction].springify();
+  if (config.damping !== undefined) animation = animation.damping(config.damping);
+  if (config.stiffness !== undefined) animation = animation.stiffness(config.stiffness);
+  if (config.mass !== undefined) animation = animation.mass(config.mass);
+  return animation;
+};
+
+/**
+ * Create a springified slide-out animation from a direction + spring config.
+ * @example createSlideOut('down', spring.snappy)
+ */
+export const createSlideOut = (
+  direction: SlideDirection,
+  config: WorkletSpringConfig = spring.snappy,
+) => {
+  let animation = slideOutMap[direction].springify();
+  if (config.damping !== undefined) animation = animation.damping(config.damping);
+  if (config.stiffness !== undefined) animation = animation.stiffness(config.stiffness);
+  if (config.mass !== undefined) animation = animation.mass(config.mass);
+  return animation;
+};
+
+/**
+ * Create a custom LinearTransition from a spring config.
+ * @example createLayoutTransition(spring.soft)
+ */
+export const createLayoutTransition = (config: WorkletSpringConfig) => {
+  let transition = LinearTransition.springify();
+  if (config.damping !== undefined) transition = transition.damping(config.damping);
+  if (config.stiffness !== undefined) transition = transition.stiffness(config.stiffness);
+  if (config.mass !== undefined) transition = transition.mass(config.mass);
+  return transition;
+};
+
+/**
+ * Create a timed fade-in animation.
+ * @example createFadeIn(300, Easing.ease)
+ */
+export const createFadeIn = (duration: number, easing?: Parameters<typeof FadeIn.easing>[0]) => {
+  const animation = FadeIn.duration(duration);
+  return easing ? animation.easing(easing) : animation;
+};
+
+/**
+ * Create a timed fade-out animation.
+ * @example createFadeOut(200)
+ */
+export const createFadeOut = (duration: number, easing?: Parameters<typeof FadeOut.easing>[0]) => {
+  const animation = FadeOut.duration(duration);
+  return easing ? animation.easing(easing) : animation;
+};

--- a/src/infrastructure/animation/index.ts
+++ b/src/infrastructure/animation/index.ts
@@ -1,0 +1,33 @@
+// ─── Token constants (single source of truth) ──────────────────
+export { spring, timing, PRESS_SCALE_VALUE } from './springs';
+
+// ─── Types ──────────────────────────────────────────────────────
+export type { WorkletSpringConfig, TimingPreset } from './springs';
+
+// ─── Animation factory functions ────────────────────────────────
+export {
+  // Layout transitions
+  softLayout,
+  snappyLayout,
+  // Slide animations
+  snappySlideInDown,
+  snappySlideInUp,
+  snappySlideOutDown,
+  // Fade animations
+  quickFadeIn,
+  fastFadeIn,
+  standardFadeIn,
+  standardFadeOut,
+  contentFadeIn,
+  contentFadeOut,
+  contentFadeInLinear,
+  slowFadeIn,
+  instantFadeOut,
+  fastFadeOut,
+  // Generic factories
+  createSlideIn,
+  createSlideOut,
+  createLayoutTransition,
+  createFadeIn,
+  createFadeOut,
+} from './animations';

--- a/src/infrastructure/animation/springs.ts
+++ b/src/infrastructure/animation/springs.ts
@@ -1,0 +1,123 @@
+import type { WithSpringConfig } from 'react-native-reanimated';
+
+// ─── Types ──────────────────────────────────────────────────────
+
+/**
+ * A spring config safe for use inside worklets.
+ * Must be a plain object — no closures, no class instances.
+ */
+export type WorkletSpringConfig = WithSpringConfig;
+
+/**
+ * A timing config for withTiming animations.
+ */
+export type TimingPreset = {
+  readonly duration: number;
+};
+
+// ─── Spring Tokens ──────────────────────────────────────────────
+
+/**
+ * Spring animation tokens — the single source of truth.
+ *
+ * Plain objects (`as const`) — safe for worklets, safe for spreading.
+ * Grouped by usage pattern, not by numeric similarity.
+ *
+ * Usage:
+ *   import { spring } from '@infrastructure/animation';
+ *   withSpring(value, spring.soft);
+ */
+export const spring = {
+  /** Soft, organic UI transitions (layout shifts, opacity, scale). */
+  soft: {
+    damping: 28,
+    stiffness: 200,
+  },
+
+  /** Snappy overlay transitions (slide-in panels, entering/exiting sheets). */
+  snappy: {
+    damping: 80,
+    stiffness: 240,
+  },
+
+  /** Bottom sheet snap animation. */
+  sheet: {
+    mass: 1,
+    stiffness: 420,
+    damping: 80,
+  },
+
+  /** Tab bar enter transition. */
+  tabEnter: {
+    damping: 30,
+    stiffness: 360,
+    mass: 1,
+  },
+
+  /** Tab bar exit transition. */
+  tabExit: {
+    damping: 28,
+    stiffness: 360,
+    mass: 1,
+  },
+
+  /** Swipeable row close animation. */
+  swipeClose: {
+    damping: 30,
+    stiffness: 360,
+    mass: 1,
+  },
+
+  /** Tap/press gesture feedback. */
+  tapFeedback: {
+    damping: 25,
+    stiffness: 120,
+  },
+
+  /** Press-and-hold scale animation (useScaleAnimation default). */
+  pressScale: {
+    mass: 1,
+    damping: 28,
+    stiffness: 200,
+    overshootClamping: true,
+  },
+
+  /** Keyboard tracking animation (iOS). Very heavy, overdamped. */
+  keyboard: {
+    damping: 500,
+    stiffness: 1000,
+    mass: 3,
+    overshootClamping: true,
+  },
+} as const satisfies Record<string, WorkletSpringConfig>;
+
+// ─── Timing Tokens ──────────────────────────────────────────────
+
+/**
+ * Timing animation presets.
+ *
+ * Usage:
+ *   import { timing } from '@infrastructure/animation';
+ *   withTiming(value, timing.standard);
+ */
+export const timing = {
+  /** 150ms — quick dismiss, fast feedback */
+  quick: { duration: 150 },
+
+  /** 200ms — fast exit transitions, screen transition exits */
+  fast: { duration: 200 },
+
+  /** 250ms — standard UI transition, opacity toggle */
+  standard: { duration: 250 },
+
+  /** 300ms — content appearance, media fade-in, progress bars */
+  content: { duration: 300 },
+
+  /** 350ms — deliberate transitions, text message cells */
+  slow: { duration: 350 },
+} as const satisfies Record<string, TimingPreset>;
+
+// ─── Constants ──────────────────────────────────────────────────
+
+/** Default scale value for press animations. Matches useScaleAnimation default. */
+export const PRESS_SCALE_VALUE = 0.96;

--- a/src/infrastructure/hooks/useHeaderAnimation.ts
+++ b/src/infrastructure/hooks/useHeaderAnimation.ts
@@ -9,8 +9,8 @@ export const useHeaderAnimation = () => {
         transform: [{ scale: 0.95 }],
       },
       animations: {
-        opacity: withDelay(200, withSpring(1)),
-        transform: [{ scale: withDelay(200, withSpring(1)) }],
+        opacity: withDelay(200, withSpring(1, { damping: 28, stiffness: 200 })),
+        transform: [{ scale: withDelay(200, withSpring(1, { damping: 28, stiffness: 200 })) }],
       },
     };
   };
@@ -23,8 +23,8 @@ export const useHeaderAnimation = () => {
         transform: [{ scale: 1 }],
       },
       animations: {
-        opacity: withSpring(0),
-        transform: [{ scale: withSpring(0.95) }],
+        opacity: withSpring(0, { damping: 28, stiffness: 200 }),
+        transform: [{ scale: withSpring(0.95, { damping: 28, stiffness: 200 }) }],
       },
     };
   };

--- a/src/infrastructure/hooks/useHeaderAnimation.ts
+++ b/src/infrastructure/hooks/useHeaderAnimation.ts
@@ -1,5 +1,7 @@
 import { withDelay, withSpring } from 'react-native-reanimated';
 
+import { spring } from '@infrastructure/animation';
+
 export const useHeaderAnimation = () => {
   const entering = () => {
     'worklet';
@@ -9,8 +11,8 @@ export const useHeaderAnimation = () => {
         transform: [{ scale: 0.95 }],
       },
       animations: {
-        opacity: withDelay(200, withSpring(1, { damping: 28, stiffness: 200 })),
-        transform: [{ scale: withDelay(200, withSpring(1, { damping: 28, stiffness: 200 })) }],
+        opacity: withDelay(200, withSpring(1, spring.soft)),
+        transform: [{ scale: withDelay(200, withSpring(1, spring.soft)) }],
       },
     };
   };
@@ -23,8 +25,8 @@ export const useHeaderAnimation = () => {
         transform: [{ scale: 1 }],
       },
       animations: {
-        opacity: withSpring(0, { damping: 28, stiffness: 200 }),
-        transform: [{ scale: withSpring(0.95, { damping: 28, stiffness: 200 }) }],
+        opacity: withSpring(0, spring.soft),
+        transform: [{ scale: withSpring(0.95, spring.soft) }],
       },
     };
   };

--- a/src/infrastructure/performance/FirebasePerformanceService.ts
+++ b/src/infrastructure/performance/FirebasePerformanceService.ts
@@ -3,6 +3,7 @@ import perf from '@react-native-firebase/perf';
 import type { IPerformanceService, IPerformanceTrace } from '@/domain/interfaces/services/shared';
 import { normalizeEventName } from '@infrastructure/utils/normalizeEventName';
 import { FirebasePerformanceTraceAdapter } from './adapters';
+import { isFirebaseInitialized } from '@infrastructure/utils/firebaseUtils';
 
 const SCREEN_TRACE_PREFIX = 'screen_';
 
@@ -15,6 +16,10 @@ export class FirebasePerformanceService implements IPerformanceService {
 
   setCollectionEnabled(enabled: boolean): void {
     this.collectionEnabled = enabled;
+    if (!isFirebaseInitialized()) {
+      console.warn('[Firebase] Not initialized — skipping setPerformanceCollectionEnabled');
+      return;
+    }
     perf()
       .setPerformanceCollectionEnabled(enabled)
       .catch(() => {
@@ -27,6 +32,11 @@ export class FirebasePerformanceService implements IPerformanceService {
 
     const normalizedName = normalizeEventName(traceName);
     if (!normalizedName) return null;
+
+    if (!isFirebaseInitialized()) {
+      console.warn('[Firebase] Not initialized — skipping startTrace');
+      return null;
+    }
 
     try {
       const firebaseTrace = await perf().startTrace(normalizedName);

--- a/src/infrastructure/ui/action-tabs/ActionTabs.tsx
+++ b/src/infrastructure/ui/action-tabs/ActionTabs.tsx
@@ -25,7 +25,7 @@ const SCREEN_WIDTH = Dimensions.get('screen').width;
 
 const AnimatedBlurView = Animated.createAnimatedComponent(BlurView);
 
-const tabExitSpringConfig = { damping: 20, stiffness: 360, mass: 1 };
+const tabExitSpringConfig = { damping: 28, stiffness: 360, mass: 1 };
 const tabEnterSpringConfig = { damping: 30, stiffness: 360, mass: 1 };
 
 type ActionTabBarBackgroundProps = BlurViewProps & PropsWithChildren;

--- a/src/infrastructure/ui/action-tabs/ActionTabs.tsx
+++ b/src/infrastructure/ui/action-tabs/ActionTabs.tsx
@@ -13,6 +13,7 @@ import { BlurView, BlurViewProps } from 'expo-blur';
 import { TAB_BAR_HEIGHT } from '@domain/constants';
 import { useRefsContext } from '@infrastructure/context';
 import { tailwind, useThemeColors } from '@infrastructure/theme';
+import { spring } from '@infrastructure/animation';
 import { useHaptic, useScaleAnimation } from '@infrastructure/utils';
 import { Icon } from '../common';
 import { useAppDispatch, useAppSelector } from '@/hooks';
@@ -24,9 +25,6 @@ const ACTION_TAB_HEIGHT = 58;
 const SCREEN_WIDTH = Dimensions.get('screen').width;
 
 const AnimatedBlurView = Animated.createAnimatedComponent(BlurView);
-
-const tabExitSpringConfig = { damping: 28, stiffness: 360, mass: 1 };
-const tabEnterSpringConfig = { damping: 30, stiffness: 360, mass: 1 };
 
 type ActionTabBarBackgroundProps = BlurViewProps & PropsWithChildren;
 
@@ -74,9 +72,7 @@ const ActionTabBarBackground = (props: ActionTabBarBackgroundProps) => {
   const currentState = useAppSelector(selectCurrentState);
 
   const derivedAnimatedState = useDerivedValue(() =>
-    currentState === 'Select'
-      ? withSpring(0, tabEnterSpringConfig)
-      : withSpring(1, tabExitSpringConfig),
+    currentState === 'Select' ? withSpring(0, spring.tabEnter) : withSpring(1, spring.tabExit),
   );
 
   const animatedTabBarStyle = useAnimatedStyle(() => {

--- a/src/infrastructure/ui/common/bottomsheet/BottomSheet.stories.tsx
+++ b/src/infrastructure/ui/common/bottomsheet/BottomSheet.stories.tsx
@@ -5,8 +5,8 @@ import {
   BottomSheetModal,
   BottomSheetScrollView,
   BottomSheetModalProvider,
+  useBottomSheetSpringConfigs,
 } from '@gorhom/bottom-sheet';
-import { useBottomSheetSpringConfigs } from '@gorhom/bottom-sheet';
 
 import { BottomSheetHeader } from './BottomSheetHeader';
 import { BottomSheetBackdrop } from './BottomSheetBackdrop';
@@ -36,7 +36,7 @@ export const LanguageSelectorSheet = () => {
   const animationConfigs = useBottomSheetSpringConfigs({
     mass: 1,
     stiffness: 420,
-    damping: 30,
+    damping: 80,
   });
 
   const { languagesModalSheetRef } = useRefsContext();

--- a/src/infrastructure/ui/common/bottomsheet/BottomSheet.stories.tsx
+++ b/src/infrastructure/ui/common/bottomsheet/BottomSheet.stories.tsx
@@ -5,8 +5,8 @@ import {
   BottomSheetModal,
   BottomSheetScrollView,
   BottomSheetModalProvider,
-  useBottomSheetSpringConfigs,
 } from '@gorhom/bottom-sheet';
+import { spring } from '@infrastructure/animation';
 
 import { BottomSheetHeader } from './BottomSheetHeader';
 import { BottomSheetBackdrop } from './BottomSheetBackdrop';
@@ -33,12 +33,6 @@ export default {
 } satisfies Meta<typeof BottomSheetModal>;
 
 export const LanguageSelectorSheet = () => {
-  const animationConfigs = useBottomSheetSpringConfigs({
-    mass: 1,
-    stiffness: 420,
-    damping: 80,
-  });
-
   const { languagesModalSheetRef } = useRefsContext();
 
   const handleOpenPress = () => {
@@ -55,7 +49,7 @@ export const LanguageSelectorSheet = () => {
         handleIndicatorStyle={tailwind.style('overflow-hidden bg-blackA-A6 w-8 h-1 rounded-[11px]')}
         detached
         enablePanDownToClose
-        animationConfigs={animationConfigs}
+        animationConfigs={spring.sheet}
         handleStyle={tailwind.style('p-0 h-4 pt-[5px]')}
         style={tailwind.style('overflow-hidden')}
         snapPoints={['70%']}>

--- a/src/infrastructure/ui/common/filters/FilterBar.tsx
+++ b/src/infrastructure/ui/common/filters/FilterBar.tsx
@@ -47,7 +47,7 @@ export const FilterBar = ({ allFilters, selectedFilters, onFilterPress }: Filter
         if (value.type === 'inbox_id') {
           return (
             <Animated.View
-              layout={LinearTransition.springify().stiffness(200).damping(24)}
+              layout={LinearTransition.springify().stiffness(200).damping(28)}
               key={index}
               style={tailwind.style('pr-2')}>
               <FilterButton
@@ -59,7 +59,7 @@ export const FilterBar = ({ allFilters, selectedFilters, onFilterPress }: Filter
         }
         return (
           <Animated.View
-            layout={LinearTransition.springify().stiffness(200).damping(24)}
+            layout={LinearTransition.springify().stiffness(200).damping(28)}
             key={index}
             style={tailwind.style('pr-2')}>
             <FilterButton

--- a/src/infrastructure/ui/common/filters/FilterBar.tsx
+++ b/src/infrastructure/ui/common/filters/FilterBar.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import Animated, { LinearTransition, withTiming } from 'react-native-reanimated';
+import Animated, { withTiming } from 'react-native-reanimated';
+import { softLayout } from '@infrastructure/animation';
 import { tailwind } from '@infrastructure/theme';
 import { FilterButton } from './FilterButton';
 import i18n from '@infrastructure/i18n';
@@ -46,10 +47,7 @@ export const FilterBar = ({ allFilters, selectedFilters, onFilterPress }: Filter
       {allFilters.map((value, index) => {
         if (value.type === 'inbox_id') {
           return (
-            <Animated.View
-              layout={LinearTransition.springify().stiffness(200).damping(28)}
-              key={index}
-              style={tailwind.style('pr-2')}>
+            <Animated.View layout={softLayout()} key={index} style={tailwind.style('pr-2')}>
               <FilterButton
                 handleOnPress={() => onFilterPress(value.type)}
                 value={value.options[selectedFilters[value.type] as keyof typeof value.options]}
@@ -58,10 +56,7 @@ export const FilterBar = ({ allFilters, selectedFilters, onFilterPress }: Filter
           );
         }
         return (
-          <Animated.View
-            layout={LinearTransition.springify().stiffness(200).damping(28)}
-            key={index}
-            style={tailwind.style('pr-2')}>
+          <Animated.View layout={softLayout()} key={index} style={tailwind.style('pr-2')}>
             <FilterButton
               handleOnPress={() => onFilterPress(value.type)}
               value={getFilterTitle(value)}

--- a/src/infrastructure/ui/common/filters/FilterBar.tsx
+++ b/src/infrastructure/ui/common/filters/FilterBar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Animated, { withTiming } from 'react-native-reanimated';
-import { softLayout } from '@infrastructure/animation';
+import { softLayout, timing } from '@infrastructure/animation';
 import { tailwind } from '@infrastructure/theme';
 import { FilterButton } from './FilterButton';
 import i18n from '@infrastructure/i18n';
@@ -23,7 +23,7 @@ export const FilterBar = ({ allFilters, selectedFilters, onFilterPress }: Filter
   const exiting = () => {
     'worklet';
     const animations = {
-      opacity: withTiming(0, { duration: 250 }),
+      opacity: withTiming(0, timing.standard),
     };
     const initialValues = {
       opacity: 1,

--- a/src/infrastructure/ui/common/search/SearchBar.tsx
+++ b/src/infrastructure/ui/common/search/SearchBar.tsx
@@ -4,6 +4,7 @@ import Animated, { withTiming } from 'react-native-reanimated';
 import { BottomSheetTextInput } from '@gorhom/bottom-sheet';
 
 import { SearchIcon } from '@/svg-icons';
+import { timing } from '@infrastructure/animation';
 import { tailwind, useThemeColors } from '@infrastructure/theme';
 import { RenderPropType } from '@domain/types';
 import { Spinner } from '@infrastructure/ui/spinner';
@@ -23,7 +24,7 @@ export const SearchBar = (props: SearchBarProps) => {
   const exiting = () => {
     'worklet';
     const animations = {
-      opacity: withTiming(0, { duration: 250 }),
+      opacity: withTiming(0, timing.standard),
     };
     const initialValues = {
       opacity: 1,

--- a/src/infrastructure/ui/common/slider/Slider.tsx
+++ b/src/infrastructure/ui/common/slider/Slider.tsx
@@ -18,8 +18,8 @@ import { tailwind } from '@infrastructure/theme';
 
 const DefaultSpringConfig: WithSpringConfig = {
   mass: 1,
-  damping: 18,
-  stiffness: 280,
+  damping: 28,
+  stiffness: 200,
 };
 
 type SliderProps = {
@@ -99,7 +99,9 @@ export const Slider = (props: SliderProps) => {
           translateX: translationX.value,
         },
       ],
-      borderWidth: sliderActive.value ? withSpring(2) : withSpring(0),
+      borderWidth: sliderActive.value
+        ? withSpring(2, { damping: 28, stiffness: 200 })
+        : withSpring(0, { damping: 28, stiffness: 200 }),
     }),
     [],
   );

--- a/src/infrastructure/ui/common/slider/Slider.tsx
+++ b/src/infrastructure/ui/common/slider/Slider.tsx
@@ -11,16 +11,10 @@ import Animated, {
   useAnimatedStyle,
   useSharedValue,
   withSpring,
-  WithSpringConfig,
 } from 'react-native-reanimated';
 
 import { tailwind } from '@infrastructure/theme';
-
-const DefaultSpringConfig: WithSpringConfig = {
-  mass: 1,
-  damping: 28,
-  stiffness: 200,
-};
+import { spring } from '@infrastructure/animation';
 
 type SliderProps = {
   currentPosition: SharedValue<number>;
@@ -56,10 +50,7 @@ export const Slider = (props: SliderProps) => {
     (next, _prev) => {
       translationX.value = withSpring(
         interpolate(next, [0, totalDuration.value], [0, sliderMaxWidth.value - 16]),
-        {
-          damping: 24,
-          stiffness: 200,
-        },
+        { ...spring.soft, damping: 24 },
       );
     },
     [],
@@ -68,7 +59,7 @@ export const Slider = (props: SliderProps) => {
   const panGesture = Gesture.Pan()
     .onBegin(() => {
       runOnJS(pauseAudio)();
-      sliderActive.value = withSpring(1, DefaultSpringConfig);
+      sliderActive.value = withSpring(1, spring.soft);
       context.value = { x: translationX.value };
     })
     .onUpdate(event => {
@@ -87,7 +78,7 @@ export const Slider = (props: SliderProps) => {
       );
       runOnJS(manualSeekTo)(seekToValue);
     })
-    .onFinalize(() => (sliderActive.value = withSpring(0, DefaultSpringConfig)));
+    .onFinalize(() => (sliderActive.value = withSpring(0, spring.soft)));
 
   const handleLayout = (e: LayoutChangeEvent) =>
     (sliderMaxWidth.value = e.nativeEvent.layout.width);
@@ -99,9 +90,7 @@ export const Slider = (props: SliderProps) => {
           translateX: translationX.value,
         },
       ],
-      borderWidth: sliderActive.value
-        ? withSpring(2, { damping: 28, stiffness: 200 })
-        : withSpring(0, { damping: 28, stiffness: 200 }),
+      borderWidth: sliderActive.value ? withSpring(2, spring.soft) : withSpring(0, spring.soft),
     }),
     [],
   );

--- a/src/infrastructure/ui/common/swipeable/Swipeable.tsx
+++ b/src/infrastructure/ui/common/swipeable/Swipeable.tsx
@@ -28,8 +28,6 @@ const DRAG_TOSS = 0.05;
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
-const rowCloseSpringConfig = { damping: 30, stiffness: 360, mass: 1 };
-
 export type SwipeableProps = {
   /**
    * The content inside the Swipeable component.
@@ -161,7 +159,7 @@ export const Swipeable = forwardRef((props: SwipeableProps, _ref) => {
 
   const closeRow = () => {
     'worklet';
-    animStatePos.value = withSpring(0, rowCloseSpringConfig);
+    animStatePos.value = withSpring(0, spring.swipeClose);
     startX.value = 0;
   };
 
@@ -197,12 +195,12 @@ export const Swipeable = forwardRef((props: SwipeableProps, _ref) => {
     .minDuration(250)
     .maxDistance(20)
     .onStart(() => handleLongPress && runOnJS(handleLongPress)())
-    .onFinalize(() => (isTapped.value = withSpring(0, { damping: 25, stiffness: 120 })));
+    .onFinalize(() => (isTapped.value = withSpring(0, spring.tapFeedback)));
 
   const tapGesture = Gesture.Tap()
-    .onBegin(() => (isTapped.value = withSpring(1, { damping: 25, stiffness: 120 })))
+    .onBegin(() => (isTapped.value = withSpring(1, spring.tapFeedback)))
     .onEnd(() => runOnJS(handlePress)())
-    .onFinalize(() => (isTapped.value = withSpring(0, { damping: 25, stiffness: 120 })));
+    .onFinalize(() => (isTapped.value = withSpring(0, spring.tapFeedback)));
 
   const panGesture = Gesture.Pan()
     .maxPointers(noOfPointers)
@@ -211,7 +209,7 @@ export const Swipeable = forwardRef((props: SwipeableProps, _ref) => {
       dragOverSwiped.value = false;
     })
     .onStart(() => {
-      isTapped.value = withSpring(0, { damping: 25, stiffness: 120 });
+      isTapped.value = withSpring(0, spring.tapFeedback);
       startX.value = animStatePos.value;
       isGestureActive.value = true;
       openedRowIndex.value = index;
@@ -283,7 +281,7 @@ export const Swipeable = forwardRef((props: SwipeableProps, _ref) => {
         }
         animStatePos.value = withSpring(
           0,
-          { ...rowCloseSpringConfig, velocity: evt.velocityX / 15 },
+          { ...spring.swipeClose, velocity: evt.velocityX / 15 },
           finished => {
             if (finished) {
               isGestureActive.value = false;
@@ -303,7 +301,7 @@ export const Swipeable = forwardRef((props: SwipeableProps, _ref) => {
         }
         animStatePos.value = withSpring(
           0,
-          { ...rowCloseSpringConfig, velocity: evt.velocityX / 15 },
+          { ...spring.swipeClose, velocity: evt.velocityX / 15 },
           finished => {
             if (finished) {
               isGestureActive.value = false;
@@ -325,7 +323,7 @@ export const Swipeable = forwardRef((props: SwipeableProps, _ref) => {
         }
         animStatePos.value = withSpring(
           0,
-          { ...rowCloseSpringConfig, velocity: evt.velocityX / 15 },
+          { ...spring.swipeClose, velocity: evt.velocityX / 15 },
           finished => {
             if (finished) {
               isGestureActive.value = false;
@@ -355,15 +353,11 @@ export const Swipeable = forwardRef((props: SwipeableProps, _ref) => {
           return diff < prevDiff ? cur : acc;
         }, Infinity);
 
-        animStatePos.value = withSpring(
-          closestSnapPoint,
-          { damping: 30, stiffness: 360, mass: 1 },
-          finished => {
-            if (finished) {
-              isGestureActive.value = false;
-            }
-          },
-        );
+        animStatePos.value = withSpring(closestSnapPoint, spring.swipeClose, finished => {
+          if (finished) {
+            isGestureActive.value = false;
+          }
+        });
       }
     });
 

--- a/src/infrastructure/ui/common/swipeable/Swipeable.tsx
+++ b/src/infrastructure/ui/common/swipeable/Swipeable.tsx
@@ -3,7 +3,6 @@ import { Dimensions, Pressable, StyleSheet } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   Extrapolation,
-  FadeIn,
   interpolate,
   interpolateColor,
   runOnJS,
@@ -15,7 +14,7 @@ import Animated, {
   withSpring,
 } from 'react-native-reanimated';
 
-import { spring, softLayout } from '@infrastructure/animation';
+import { spring, softLayout, fastFadeIn } from '@infrastructure/animation';
 import { tailwind } from '@infrastructure/theme';
 import { useHaptic } from '@infrastructure/utils';
 import { AnimatedNativeView } from '@infrastructure/ui/native-components';
@@ -461,7 +460,7 @@ export const Swipeable = forwardRef((props: SwipeableProps, _ref) => {
       </AnimatedPressable>
       <GestureDetector gesture={cellGestures}>
         <AnimatedNativeView
-          entering={FadeIn.duration(200)}
+          entering={fastFadeIn()}
           layout={softLayout()}
           style={[tailwind.style('flex-1 z-10', `w-[${WIDTH}px]`), overlayStyle, tappedCellStyle]}>
           {children}

--- a/src/infrastructure/ui/common/swipeable/Swipeable.tsx
+++ b/src/infrastructure/ui/common/swipeable/Swipeable.tsx
@@ -1,6 +1,5 @@
-/* eslint-disable @typescript-eslint/no-unused-expressions */
 import React, { forwardRef, useCallback } from 'react';
-import { Dimensions, Platform, Pressable, StyleSheet } from 'react-native';
+import { Dimensions, Pressable, StyleSheet } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   Extrapolation,
@@ -10,7 +9,6 @@ import Animated, {
   LinearTransition,
   runOnJS,
   SharedValue,
-  SlideInDown,
   useAnimatedReaction,
   useAnimatedStyle,
   useDerivedValue,
@@ -470,14 +468,7 @@ export const Swipeable = forwardRef((props: SwipeableProps, _ref) => {
       </AnimatedPressable>
       <GestureDetector gesture={cellGestures}>
         <AnimatedNativeView
-          entering={
-            Platform.OS === 'ios'
-              ? SlideInDown.delay(index * 20)
-                  .springify()
-                  .damping(20)
-                  .stiffness(120)
-              : FadeIn
-          }
+          entering={FadeIn.duration(200)}
           layout={LinearTransition.springify().damping(28).stiffness(200)}
           style={[tailwind.style('flex-1 z-10', `w-[${WIDTH}px]`), overlayStyle, tappedCellStyle]}>
           {children}

--- a/src/infrastructure/ui/common/swipeable/Swipeable.tsx
+++ b/src/infrastructure/ui/common/swipeable/Swipeable.tsx
@@ -6,7 +6,6 @@ import Animated, {
   FadeIn,
   interpolate,
   interpolateColor,
-  LinearTransition,
   runOnJS,
   SharedValue,
   useAnimatedReaction,
@@ -16,7 +15,7 @@ import Animated, {
   withSpring,
 } from 'react-native-reanimated';
 
-import { spring } from '@infrastructure/animation';
+import { spring, softLayout } from '@infrastructure/animation';
 import { tailwind } from '@infrastructure/theme';
 import { useHaptic } from '@infrastructure/utils';
 import { AnimatedNativeView } from '@infrastructure/ui/native-components';
@@ -469,7 +468,7 @@ export const Swipeable = forwardRef((props: SwipeableProps, _ref) => {
       <GestureDetector gesture={cellGestures}>
         <AnimatedNativeView
           entering={FadeIn.duration(200)}
-          layout={LinearTransition.springify().damping(28).stiffness(200)}
+          layout={softLayout()}
           style={[tailwind.style('flex-1 z-10', `w-[${WIDTH}px]`), overlayStyle, tappedCellStyle]}>
           {children}
         </AnimatedNativeView>

--- a/src/infrastructure/ui/common/swipeable/Swipeable.tsx
+++ b/src/infrastructure/ui/common/swipeable/Swipeable.tsx
@@ -29,7 +29,7 @@ const DRAG_TOSS = 0.05;
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
 const rowCloseSpringConfig = { damping: 30, stiffness: 360, mass: 1 };
-const overSwipedSpringConfig = { damping: 20, stiffness: 180 };
+const overSwipedSpringConfig = { damping: 28, stiffness: 200 };
 
 export type SwipeableProps = {
   /**

--- a/src/infrastructure/ui/common/swipeable/Swipeable.tsx
+++ b/src/infrastructure/ui/common/swipeable/Swipeable.tsx
@@ -16,6 +16,7 @@ import Animated, {
   withSpring,
 } from 'react-native-reanimated';
 
+import { spring } from '@infrastructure/animation';
 import { tailwind } from '@infrastructure/theme';
 import { useHaptic } from '@infrastructure/utils';
 import { AnimatedNativeView } from '@infrastructure/ui/native-components';
@@ -29,7 +30,6 @@ const DRAG_TOSS = 0.05;
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
 const rowCloseSpringConfig = { damping: 30, stiffness: 360, mass: 1 };
-const overSwipedSpringConfig = { damping: 28, stiffness: 200 };
 
 export type SwipeableProps = {
   /**
@@ -236,7 +236,7 @@ export const Swipeable = forwardRef((props: SwipeableProps, _ref) => {
         // We might have to trigger the overswipe action when it is swiped in higher speed
         // Setting a variable to know that its going to an over swiped case
         dragOverSwiped.value = true;
-        overSwipedState.value = withSpring(1, overSwipedSpringConfig);
+        overSwipedState.value = withSpring(1, spring.soft);
         // Calculate a higher spring config for the rubber band effect
         const distanceBeyondMax = Math.abs(clampedVal) - maxTranslation;
         const springFactor = distanceBeyondMax * FRICTION;
@@ -245,7 +245,7 @@ export const Swipeable = forwardRef((props: SwipeableProps, _ref) => {
         stiffnessValue += springFactor;
       } else {
         if (dragOverSwiped.value) {
-          overSwipedState.value = withSpring(0, overSwipedSpringConfig, finished => {
+          overSwipedState.value = withSpring(0, spring.soft, finished => {
             if (finished) {
               dragOverSwiped.value = false;
             }

--- a/src/infrastructure/ui/no-network/NoNetwork.tsx
+++ b/src/infrastructure/ui/no-network/NoNetwork.tsx
@@ -25,7 +25,7 @@ export const NoNetworkBar = () => {
       duration: animationConstants.DURATION,
       toValue: animationConstants.TO_VALUE,
       useNativeDriver: true,
-      easing: Easing.bounce,
+      easing: Easing.out(Easing.cubic),
     }).start();
   }, [animation, animationConstants]);
 

--- a/src/infrastructure/ui/verification-code/animated-code-number.tsx
+++ b/src/infrastructure/ui/verification-code/animated-code-number.tsx
@@ -3,13 +3,12 @@ import type { SharedValue } from 'react-native-reanimated';
 import { tailwind } from '@infrastructure/theme';
 import Animated, {
   Easing,
-  FadeIn,
-  FadeOut,
   FlipInXDown,
   FlipOutXDown,
   useAnimatedStyle,
   withTiming,
 } from 'react-native-reanimated';
+import { standardFadeIn, standardFadeOut } from '@infrastructure/animation';
 
 export type StatusType = 'inProgress' | 'correct' | 'wrong';
 
@@ -37,7 +36,7 @@ export const AnimatedCodeNumber: React.FC<AnimatedCodeNumberProps> = ({
   return (
     <Animated.View style={[styles.container, rBoxStyle]}>
       {code != null && (
-        <Animated.View entering={FadeIn.duration(250)} exiting={FadeOut.duration(250)}>
+        <Animated.View entering={standardFadeIn()} exiting={standardFadeOut()}>
           <Animated.Text
             entering={FlipInXDown.duration(500)
               // Go to this website and you'll see the curve I used:

--- a/src/infrastructure/utils/__tests__/imageUtils.test.ts
+++ b/src/infrastructure/utils/__tests__/imageUtils.test.ts
@@ -1,0 +1,31 @@
+import { replaceExtension } from '@infrastructure/utils/imageUtils';
+
+describe('replaceExtension', () => {
+  it('should replace a standard extension', () => {
+    expect(replaceExtension('photo.heic', '.jpg')).toBe('photo.jpg');
+  });
+
+  it('should replace only the last extension when filename has multiple dots', () => {
+    expect(replaceExtension('my.vacation.photo.HEIC', '.jpg')).toBe('my.vacation.photo.jpg');
+  });
+
+  it('should append extension when filename has no dot', () => {
+    expect(replaceExtension('photo', '.jpg')).toBe('photo.jpg');
+  });
+
+  it('should return undefined when fileName is undefined', () => {
+    expect(replaceExtension(undefined, '.jpg')).toBeUndefined();
+  });
+
+  it('should return empty string when fileName is empty', () => {
+    expect(replaceExtension('', '.jpg')).toBe('');
+  });
+
+  it('should handle uppercase extensions', () => {
+    expect(replaceExtension('IMG_0111.HEIC', '.jpg')).toBe('IMG_0111.jpg');
+  });
+
+  it('should preserve path segments before the filename', () => {
+    expect(replaceExtension('photos/IMG_0111.heic', '.jpg')).toBe('photos/IMG_0111.jpg');
+  });
+});

--- a/src/infrastructure/utils/common.ts
+++ b/src/infrastructure/utils/common.ts
@@ -1,7 +1,14 @@
 import { Platform } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { TAB_BAR_HEIGHT } from '@domain/constants';
 
 export const useTabBarHeight = () => {
-  return Platform.OS === 'ios' ? TAB_BAR_HEIGHT : TAB_BAR_HEIGHT - 21;
+  const { bottom } = useSafeAreaInsets();
+  // Base = TAB_BAR_HEIGHT minus the iOS safe-area allocation (32px).
+  // This gives us the fixed portion (content + top padding = 51px).
+  // Then we add back the actual bottom padding, which differs per platform.
+  const baseHeight = TAB_BAR_HEIGHT - 32;
+  const bottomPadding = Platform.OS === 'ios' ? Math.max(bottom, 32) : Math.max(bottom, 11);
+  return baseHeight + bottomPadding;
 };

--- a/src/infrastructure/utils/customAnimations.ts
+++ b/src/infrastructure/utils/customAnimations.ts
@@ -1,12 +1,14 @@
 import { withSpring } from 'react-native-reanimated';
 
+import { spring } from '@infrastructure/animation';
+
 export const photoIconExitAnimation = () => {
   'worklet';
   const animations = {
-    opacity: withSpring(0, { damping: 28, stiffness: 200 }),
+    opacity: withSpring(0, spring.soft),
     transform: [
-      { translateX: withSpring(-10, { damping: 28, stiffness: 200 }) },
-      { scale: withSpring(0.9, { damping: 28, stiffness: 200 }) },
+      { translateX: withSpring(-10, spring.soft) },
+      { scale: withSpring(0.9, spring.soft) },
     ],
   };
   const initialValues = {
@@ -22,11 +24,8 @@ export const photoIconExitAnimation = () => {
 export const photoIconEnterAnimation = () => {
   'worklet';
   const animations = {
-    opacity: withSpring(1, { damping: 28, stiffness: 200 }),
-    transform: [
-      { translateX: withSpring(0, { damping: 28, stiffness: 200 }) },
-      { scale: withSpring(1, { damping: 28, stiffness: 200 }) },
-    ],
+    opacity: withSpring(1, spring.soft),
+    transform: [{ translateX: withSpring(0, spring.soft) }, { scale: withSpring(1, spring.soft) }],
   };
   const initialValues = {
     opacity: 0,
@@ -41,8 +40,8 @@ export const photoIconEnterAnimation = () => {
 export const voiceNoteIconExitAnimation = () => {
   'worklet';
   const animations = {
-    opacity: withSpring(0, { damping: 28, stiffness: 200 }),
-    transform: [{ scale: withSpring(0.9, { damping: 28, stiffness: 200 }) }],
+    opacity: withSpring(0, spring.soft),
+    transform: [{ scale: withSpring(0.9, spring.soft) }],
   };
   const initialValues = {
     opacity: 1,
@@ -57,8 +56,8 @@ export const voiceNoteIconExitAnimation = () => {
 export const voiceNoteIconEnterAnimation = () => {
   'worklet';
   const animations = {
-    opacity: withSpring(1, { damping: 28, stiffness: 200 }),
-    transform: [{ scale: withSpring(1, { damping: 28, stiffness: 200 }) }],
+    opacity: withSpring(1, spring.soft),
+    transform: [{ scale: withSpring(1, spring.soft) }],
   };
   const initialValues = {
     opacity: 0,
@@ -73,8 +72,8 @@ export const voiceNoteIconEnterAnimation = () => {
 export const sendIconExitAnimation = () => {
   'worklet';
   const animations = {
-    opacity: withSpring(0, { damping: 28, stiffness: 200 }),
-    transform: [{ scale: withSpring(0.9, { damping: 28, stiffness: 200 }) }],
+    opacity: withSpring(0, spring.soft),
+    transform: [{ scale: withSpring(0.9, spring.soft) }],
   };
   const initialValues = {
     opacity: 1,
@@ -89,8 +88,8 @@ export const sendIconExitAnimation = () => {
 export const sendIconEnterAnimation = () => {
   'worklet';
   const animations = {
-    opacity: withSpring(1, { damping: 28, stiffness: 200 }),
-    transform: [{ scale: withSpring(1, { damping: 28, stiffness: 200 }) }],
+    opacity: withSpring(1, spring.soft),
+    transform: [{ scale: withSpring(1, spring.soft) }],
   };
   const initialValues = {
     opacity: 0,

--- a/src/infrastructure/utils/customAnimations.ts
+++ b/src/infrastructure/utils/customAnimations.ts
@@ -3,10 +3,10 @@ import { withSpring } from 'react-native-reanimated';
 export const photoIconExitAnimation = () => {
   'worklet';
   const animations = {
-    opacity: withSpring(0, { damping: 20, stiffness: 180 }),
+    opacity: withSpring(0, { damping: 28, stiffness: 200 }),
     transform: [
-      { translateX: withSpring(-10, { damping: 20, stiffness: 180 }) },
-      { scale: withSpring(0.9, { damping: 20, stiffness: 180 }) },
+      { translateX: withSpring(-10, { damping: 28, stiffness: 200 }) },
+      { scale: withSpring(0.9, { damping: 28, stiffness: 200 }) },
     ],
   };
   const initialValues = {
@@ -22,10 +22,10 @@ export const photoIconExitAnimation = () => {
 export const photoIconEnterAnimation = () => {
   'worklet';
   const animations = {
-    opacity: withSpring(1, { damping: 20, stiffness: 180 }),
+    opacity: withSpring(1, { damping: 28, stiffness: 200 }),
     transform: [
-      { translateX: withSpring(0, { damping: 20, stiffness: 180 }) },
-      { scale: withSpring(1, { damping: 20, stiffness: 180 }) },
+      { translateX: withSpring(0, { damping: 28, stiffness: 200 }) },
+      { scale: withSpring(1, { damping: 28, stiffness: 200 }) },
     ],
   };
   const initialValues = {
@@ -41,8 +41,8 @@ export const photoIconEnterAnimation = () => {
 export const voiceNoteIconExitAnimation = () => {
   'worklet';
   const animations = {
-    opacity: withSpring(0, { damping: 20, stiffness: 180 }),
-    transform: [{ scale: withSpring(0.9, { damping: 20, stiffness: 180 }) }],
+    opacity: withSpring(0, { damping: 28, stiffness: 200 }),
+    transform: [{ scale: withSpring(0.9, { damping: 28, stiffness: 200 }) }],
   };
   const initialValues = {
     opacity: 1,
@@ -57,8 +57,8 @@ export const voiceNoteIconExitAnimation = () => {
 export const voiceNoteIconEnterAnimation = () => {
   'worklet';
   const animations = {
-    opacity: withSpring(1, { damping: 20, stiffness: 180 }),
-    transform: [{ scale: withSpring(1, { damping: 20, stiffness: 180 }) }],
+    opacity: withSpring(1, { damping: 28, stiffness: 200 }),
+    transform: [{ scale: withSpring(1, { damping: 28, stiffness: 200 }) }],
   };
   const initialValues = {
     opacity: 0,
@@ -73,8 +73,8 @@ export const voiceNoteIconEnterAnimation = () => {
 export const sendIconExitAnimation = () => {
   'worklet';
   const animations = {
-    opacity: withSpring(0, { damping: 20, stiffness: 180 }),
-    transform: [{ scale: withSpring(0.9, { damping: 20, stiffness: 180 }) }],
+    opacity: withSpring(0, { damping: 28, stiffness: 200 }),
+    transform: [{ scale: withSpring(0.9, { damping: 28, stiffness: 200 }) }],
   };
   const initialValues = {
     opacity: 1,
@@ -89,8 +89,8 @@ export const sendIconExitAnimation = () => {
 export const sendIconEnterAnimation = () => {
   'worklet';
   const animations = {
-    opacity: withSpring(1, { damping: 20, stiffness: 180 }),
-    transform: [{ scale: withSpring(1, { damping: 20, stiffness: 180 }) }],
+    opacity: withSpring(1, { damping: 28, stiffness: 200 }),
+    transform: [{ scale: withSpring(1, { damping: 28, stiffness: 200 }) }],
   };
   const initialValues = {
     opacity: 0,

--- a/src/infrastructure/utils/imageUtils.ts
+++ b/src/infrastructure/utils/imageUtils.ts
@@ -1,13 +1,6 @@
-import { manipulateAsync, SaveFormat } from 'expo-image-manipulator';
-import * as FileSystem from 'expo-file-system';
+import { ImageManipulator, SaveFormat } from 'expo-image-manipulator';
+import { File } from 'expo-file-system';
 import type { PickedAsset } from '@domain/types';
-
-const HEIC_MIME_TYPES = new Set([
-  'image/heic',
-  'image/heif',
-  'image/heic-sequence',
-  'image/heif-sequence',
-]);
 
 /** MIME types that should skip processing entirely (already optimal or would lose data) */
 const PASSTHROUGH_MIME_TYPES = new Set(['image/gif', 'image/jpeg', 'image/jpg']);
@@ -21,6 +14,8 @@ const IMAGE_COMPRESS_QUALITY = 0.8;
  * - Preserves PNG alpha channel (PNG → PNG)
  * - Passes through GIF (preserves animation) and JPEG (avoids lossy re-encode)
  * - Non-image assets (video, audio, documents) are returned unchanged
+ *
+ * Uses the SDK 55 context-based ImageManipulator API and new File class.
  */
 export const processImageForUpload = async (asset: PickedAsset): Promise<PickedAsset> => {
   const mimeType = asset.type?.toLowerCase() ?? '';
@@ -40,22 +35,27 @@ export const processImageForUpload = async (asset: PickedAsset): Promise<PickedA
   }
 
   try {
-    const isHeic = HEIC_MIME_TYPES.has(mimeType);
     const isPng = mimeType === 'image/png';
 
     // HEIC → JPEG, PNG → PNG (preserve alpha), others (WebP, BMP, TIFF) → JPEG
     const outputFormat = isPng ? SaveFormat.PNG : SaveFormat.JPEG;
 
-    const result = await manipulateAsync(asset.uri, [], {
-      compress: IMAGE_COMPRESS_QUALITY,
+    // SDK 55 context API: manipulate → renderAsync → saveAsync
+    // rotate(0) forces iOS to normalize EXIF orientation into pixel data,
+    // preventing rotated output when converting HEIC → JPEG.
+    const context = ImageManipulator.manipulate(asset.uri).rotate(0);
+    const imageRef = await context.renderAsync();
+    const result = await imageRef.saveAsync({
       format: outputFormat,
+      // compress is only meaningful for JPEG; PNG is always lossless
+      ...(outputFormat === SaveFormat.JPEG && { compress: IMAGE_COMPRESS_QUALITY }),
     });
 
-    // Get actual file size after manipulation (manipulateAsync doesn't return it)
+    // Get actual file size using the new File class (SDK 55 — getInfoAsync is deprecated)
     let fileSize: number | undefined;
-    const fileInfo = await FileSystem.getInfoAsync(result.uri);
-    if (fileInfo.exists && 'size' in fileInfo) {
-      fileSize = fileInfo.size;
+    const file = new File(result.uri);
+    if (file.exists) {
+      fileSize = file.size;
     }
 
     const outputMimeType = isPng ? 'image/png' : 'image/jpeg';
@@ -64,7 +64,7 @@ export const processImageForUpload = async (asset: PickedAsset): Promise<PickedA
     // PNG keeps its original extension since format doesn't change
     const formatChanged = !isPng && mimeType !== 'image/jpeg' && mimeType !== 'image/jpg';
     const updatedFileName = formatChanged
-      ? replaceExtension(asset.fileName, isPng ? '.png' : '.jpg')
+      ? replaceExtension(asset.fileName, '.jpg')
       : asset.fileName;
 
     return {
@@ -83,9 +83,12 @@ export const processImageForUpload = async (asset: PickedAsset): Promise<PickedA
 
 /**
  * Replaces the file extension while preserving the base name.
- * Returns the original value when fileName is absent.
+ * Returns the original value when fileName is absent or empty.
  */
-const replaceExtension = (fileName: string | undefined, newExt: string): string | undefined => {
+export const replaceExtension = (
+  fileName: string | undefined,
+  newExt: string,
+): string | undefined => {
   if (!fileName) return fileName;
   const dotIndex = fileName.lastIndexOf('.');
   const baseName = dotIndex > 0 ? fileName.substring(0, dotIndex) : fileName;

--- a/src/infrastructure/utils/imageUtils.ts
+++ b/src/infrastructure/utils/imageUtils.ts
@@ -1,0 +1,77 @@
+import { manipulateAsync, SaveFormat } from 'expo-image-manipulator';
+import * as FileSystem from 'expo-file-system';
+import type { PickedAsset } from '@domain/types';
+
+const HEIC_MIME_TYPES = new Set([
+  'image/heic',
+  'image/heif',
+  'image/heic-sequence',
+  'image/heif-sequence',
+]);
+
+const IMAGE_COMPRESS_QUALITY = 0.8;
+
+/**
+ * Processes an image asset for upload:
+ * - Converts HEIC/HEIF images to JPEG (required by WHAPI / WhatsApp)
+ * - Compresses all images to reduce upload size
+ * - Non-image assets (video, audio, documents) are returned unchanged
+ */
+export const processImageForUpload = async (asset: PickedAsset): Promise<PickedAsset> => {
+  const mimeType = asset.type?.toLowerCase() ?? '';
+
+  // Only process images — return videos, audio, documents unchanged
+  if (!mimeType.startsWith('image/')) {
+    return asset;
+  }
+
+  if (!asset.uri) {
+    return asset;
+  }
+
+  try {
+    const isHeic = HEIC_MIME_TYPES.has(mimeType);
+    const isPng = mimeType === 'image/png';
+
+    // HEIC → JPEG (unsupported everywhere), PNG → PNG (preserve alpha), others → JPEG
+    const outputFormat = isPng ? SaveFormat.PNG : SaveFormat.JPEG;
+
+    const result = await manipulateAsync(asset.uri, [], {
+      compress: IMAGE_COMPRESS_QUALITY,
+      format: outputFormat,
+    });
+
+    // Get actual file size after manipulation (manipulateAsync doesn't return it)
+    let fileSize: number | undefined;
+    const fileInfo = await FileSystem.getInfoAsync(result.uri);
+    if (fileInfo.exists && 'size' in fileInfo) {
+      fileSize = fileInfo.size;
+    }
+
+    const outputMimeType = isPng ? 'image/png' : 'image/jpeg';
+    // Only change extension for HEIC→JPEG conversions; PNG keeps its extension
+    const updatedFileName = isHeic ? replaceExtension(asset.fileName, '.jpg') : asset.fileName;
+
+    return {
+      ...asset,
+      uri: result.uri,
+      type: outputMimeType,
+      fileName: updatedFileName,
+      fileSize,
+    };
+  } catch (error) {
+    console.warn('Image conversion failed, using original asset:', error);
+    return asset;
+  }
+};
+
+/**
+ * Replaces the file extension while preserving the base name.
+ * Returns the original value when fileName is absent.
+ */
+const replaceExtension = (fileName: string | undefined, newExt: string): string | undefined => {
+  if (!fileName) return fileName;
+  const dotIndex = fileName.lastIndexOf('.');
+  const baseName = dotIndex > 0 ? fileName.substring(0, dotIndex) : fileName;
+  return `${baseName}${newExt}`;
+};

--- a/src/infrastructure/utils/imageUtils.ts
+++ b/src/infrastructure/utils/imageUtils.ts
@@ -9,12 +9,17 @@ const HEIC_MIME_TYPES = new Set([
   'image/heif-sequence',
 ]);
 
+/** MIME types that should skip processing entirely (already optimal or would lose data) */
+const PASSTHROUGH_MIME_TYPES = new Set(['image/gif', 'image/jpeg', 'image/jpg']);
+
 const IMAGE_COMPRESS_QUALITY = 0.8;
 
 /**
  * Processes an image asset for upload:
  * - Converts HEIC/HEIF images to JPEG (required by WHAPI / WhatsApp)
- * - Compresses all images to reduce upload size
+ * - Converts other non-standard formats (WebP, BMP, TIFF) to JPEG
+ * - Preserves PNG alpha channel (PNG → PNG)
+ * - Passes through GIF (preserves animation) and JPEG (avoids lossy re-encode)
  * - Non-image assets (video, audio, documents) are returned unchanged
  */
 export const processImageForUpload = async (asset: PickedAsset): Promise<PickedAsset> => {
@@ -29,11 +34,16 @@ export const processImageForUpload = async (asset: PickedAsset): Promise<PickedA
     return asset;
   }
 
+  // GIF: skip to preserve animation; JPEG: skip to avoid lossy re-encoding
+  if (PASSTHROUGH_MIME_TYPES.has(mimeType)) {
+    return asset;
+  }
+
   try {
     const isHeic = HEIC_MIME_TYPES.has(mimeType);
     const isPng = mimeType === 'image/png';
 
-    // HEIC → JPEG (unsupported everywhere), PNG → PNG (preserve alpha), others → JPEG
+    // HEIC → JPEG, PNG → PNG (preserve alpha), others (WebP, BMP, TIFF) → JPEG
     const outputFormat = isPng ? SaveFormat.PNG : SaveFormat.JPEG;
 
     const result = await manipulateAsync(asset.uri, [], {
@@ -49,8 +59,13 @@ export const processImageForUpload = async (asset: PickedAsset): Promise<PickedA
     }
 
     const outputMimeType = isPng ? 'image/png' : 'image/jpeg';
-    // Only change extension for HEIC→JPEG conversions; PNG keeps its extension
-    const updatedFileName = isHeic ? replaceExtension(asset.fileName, '.jpg') : asset.fileName;
+
+    // Update extension when format changes (HEIC→.jpg, WebP→.jpg, BMP→.jpg, etc.)
+    // PNG keeps its original extension since format doesn't change
+    const formatChanged = !isPng && mimeType !== 'image/jpeg' && mimeType !== 'image/jpg';
+    const updatedFileName = formatChanged
+      ? replaceExtension(asset.fileName, isPng ? '.png' : '.jpg')
+      : asset.fileName;
 
     return {
       ...asset,
@@ -60,7 +75,8 @@ export const processImageForUpload = async (asset: PickedAsset): Promise<PickedA
       fileSize,
     };
   } catch (error) {
-    console.warn('Image conversion failed, using original asset:', error);
+    const name = asset.fileName ?? 'unknown';
+    console.warn(`Image conversion failed for "${name}" (${mimeType}), using original:`, error);
     return asset;
   }
 };

--- a/src/infrastructure/utils/index.ts
+++ b/src/infrastructure/utils/index.ts
@@ -20,3 +20,4 @@ export * from './localeUtils';
 export * from './audioConverter';
 export * from './activityMessageUtils';
 export * from './avatarUtils';
+export * from './imageUtils';

--- a/src/infrastructure/utils/permissionManager.ts
+++ b/src/infrastructure/utils/permissionManager.ts
@@ -1,5 +1,4 @@
-import { Alert, Platform, Linking } from 'react-native';
-import { PermissionsAndroid } from 'react-native';
+import { Alert, Platform, Linking, PermissionsAndroid } from 'react-native';
 import { getApp } from '@react-native-firebase/app';
 import {
   getMessaging,
@@ -8,9 +7,14 @@ import {
 } from '@react-native-firebase/messaging';
 
 import i18n from '@infrastructure/i18n';
+import { isFirebaseInitialized } from '@infrastructure/utils/firebaseUtils';
 
 export const requestNotificationPermissions = async (): Promise<boolean> => {
   try {
+    if (!isFirebaseInitialized()) {
+      console.warn('[Firebase] Not initialized — skipping requestNotificationPermissions');
+      return false;
+    }
     if (Platform.OS === 'android') {
       // Android 13+ requires explicit permission
       const apiLevel = Number(Platform.Version);

--- a/src/infrastructure/utils/useAppKeyboardAnimation.ts
+++ b/src/infrastructure/utils/useAppKeyboardAnimation.ts
@@ -1,16 +1,7 @@
 import { useKeyboardHandler } from 'react-native-keyboard-controller';
 import { useSharedValue, withSpring } from 'react-native-reanimated';
 
-const ANIMATION_CONFIGS_IOS = {
-  damping: 500,
-  stiffness: 1000,
-  mass: 3,
-  overshootClamping: true,
-  restDisplacementThreshold: 10,
-  restSpeedThreshold: 10,
-};
-
-const ANIMATION_CONFIGS = ANIMATION_CONFIGS_IOS;
+import { spring } from '@infrastructure/animation';
 
 export const useAppKeyboardAnimation = () => {
   const progress = useSharedValue(0);
@@ -18,8 +9,8 @@ export const useAppKeyboardAnimation = () => {
   useKeyboardHandler({
     onStart: e => {
       'worklet';
-      progress.value = withSpring(e.progress, ANIMATION_CONFIGS);
-      height.value = withSpring(e.height, ANIMATION_CONFIGS);
+      progress.value = withSpring(e.progress, spring.keyboard);
+      height.value = withSpring(e.height, spring.keyboard);
     },
   });
 

--- a/src/infrastructure/utils/useScaleAnimation.ts
+++ b/src/infrastructure/utils/useScaleAnimation.ts
@@ -38,9 +38,9 @@ type AnimationTypes = SpringAnimation | TimingAnimation;
 
 const DefaultSpringConfig: WithSpringConfig = {
   mass: 1,
-  damping: 17,
-  stiffness: 250,
-  overshootClamping: false,
+  damping: 28,
+  stiffness: 200,
+  overshootClamping: true,
 };
 
 const DefaultAnimationType: AnimationTypes = {

--- a/src/infrastructure/utils/useScaleAnimation.ts
+++ b/src/infrastructure/utils/useScaleAnimation.ts
@@ -8,6 +8,8 @@ import {
   WithTimingConfig,
 } from 'react-native-reanimated';
 
+import { spring, PRESS_SCALE_VALUE } from '@infrastructure/animation';
+
 type AnimationValue = {
   /**
    * The scale value to which the component should resize onPressIn
@@ -36,17 +38,10 @@ type TimingAnimation = AnimationValue & {
 
 type AnimationTypes = SpringAnimation | TimingAnimation;
 
-const DefaultSpringConfig: WithSpringConfig = {
-  mass: 1,
-  damping: 28,
-  stiffness: 200,
-  overshootClamping: true,
-};
-
 const DefaultAnimationType: AnimationTypes = {
   type: 'spring',
-  config: DefaultSpringConfig,
-  value: 0.96,
+  config: spring.pressScale,
+  value: PRESS_SCALE_VALUE,
 };
 
 export const useScaleAnimation = (scaleAnimationConfig: AnimationTypes = DefaultAnimationType) => {

--- a/src/modules/onboarding/presentation/components/ProgressBar.tsx
+++ b/src/modules/onboarding/presentation/components/ProgressBar.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { View, Text } from 'react-native';
-import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
+import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import { useThemedStyles } from '@infrastructure/hooks/useThemedStyles';
 
 interface ProgressBarProps {
@@ -28,10 +28,7 @@ export function ProgressBar({
 
   useEffect(() => {
     if (animated) {
-      width.value = withSpring(clampedProgress, {
-        damping: 15,
-        stiffness: 100,
-      });
+      width.value = withTiming(clampedProgress, { duration: 300 });
     } else {
       width.value = clampedProgress;
     }

--- a/src/modules/onboarding/presentation/components/ProgressBar.tsx
+++ b/src/modules/onboarding/presentation/components/ProgressBar.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { View, Text } from 'react-native';
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
+import { timing } from '@infrastructure/animation';
 import { useThemedStyles } from '@infrastructure/hooks/useThemedStyles';
 
 interface ProgressBarProps {
@@ -28,7 +29,7 @@ export function ProgressBar({
 
   useEffect(() => {
     if (animated) {
-      width.value = withTiming(clampedProgress, { duration: 300 });
+      width.value = withTiming(clampedProgress, timing.content);
     } else {
       width.value = clampedProgress;
     }

--- a/src/modules/onboarding/presentation/hooks/useScreenTransition.ts
+++ b/src/modules/onboarding/presentation/hooks/useScreenTransition.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { SlideInRight, SlideOutLeft, SlideInLeft, SlideOutRight } from 'react-native-reanimated';
-import { contentFadeInLinear, fastFadeOut } from '@infrastructure/animation';
+import { contentFadeInLinear, fastFadeOut, timing } from '@infrastructure/animation';
 import type { UIConfig } from '../../domain/common';
 
 type AnimationType = 'slide' | 'fade' | 'none';
@@ -27,13 +27,13 @@ export function useScreenTransition(
       case 'slide':
         if (direction === 'forward') {
           return {
-            entering: SlideInRight.duration(300),
-            exiting: SlideOutLeft.duration(200),
+            entering: SlideInRight.duration(timing.content.duration),
+            exiting: SlideOutLeft.duration(timing.fast.duration),
           };
         } else {
           return {
-            entering: SlideInLeft.duration(300),
-            exiting: SlideOutRight.duration(200),
+            entering: SlideInLeft.duration(timing.content.duration),
+            exiting: SlideOutRight.duration(timing.fast.duration),
           };
         }
 

--- a/src/modules/onboarding/presentation/hooks/useScreenTransition.ts
+++ b/src/modules/onboarding/presentation/hooks/useScreenTransition.ts
@@ -1,12 +1,6 @@
 import { useMemo } from 'react';
-import {
-  FadeIn,
-  FadeOut,
-  SlideInRight,
-  SlideOutLeft,
-  SlideInLeft,
-  SlideOutRight,
-} from 'react-native-reanimated';
+import { SlideInRight, SlideOutLeft, SlideInLeft, SlideOutRight } from 'react-native-reanimated';
+import { contentFadeInLinear, fastFadeOut } from '@infrastructure/animation';
 import type { UIConfig } from '../../domain/common';
 
 type AnimationType = 'slide' | 'fade' | 'none';
@@ -26,8 +20,8 @@ export function useScreenTransition(
     switch (animationType) {
       case 'fade':
         return {
-          entering: FadeIn.duration(300),
-          exiting: FadeOut.duration(200),
+          entering: contentFadeInLinear(),
+          exiting: fastFadeOut(),
         };
 
       case 'slide':

--- a/src/presentation/ai-chat/components/ai-assistant/AIChatSessionPanel.tsx
+++ b/src/presentation/ai-chat/components/ai-assistant/AIChatSessionPanel.tsx
@@ -1,10 +1,7 @@
 import React, { useCallback, useMemo, useRef } from 'react';
 import { View, Text } from 'react-native';
-import BottomSheet, {
-  BottomSheetScrollView,
-  BottomSheetBackdrop,
-  useBottomSheetSpringConfigs,
-} from '@gorhom/bottom-sheet';
+import BottomSheet, { BottomSheetScrollView, BottomSheetBackdrop } from '@gorhom/bottom-sheet';
+import { spring } from '@infrastructure/animation';
 import type { BottomSheetBackdropProps } from '@gorhom/bottom-sheet';
 import { AISessionList } from './AISessionList';
 import type { AIChatSession } from '@application/store/ai-chat/aiChatTypes';
@@ -27,12 +24,6 @@ export const AIChatSessionPanel: React.FC<AIChatSessionPanelProps> = React.memo(
     const sessionTokens = tokens.session;
     const bottomSheetRef = useRef<BottomSheet>(null);
     const snapPoints = useMemo(() => ['40%', '75%'], []);
-
-    const animationConfigs = useBottomSheetSpringConfigs({
-      mass: 1,
-      stiffness: 420,
-      damping: 80,
-    });
 
     const renderBackdrop = useCallback(
       (props: BottomSheetBackdropProps) => (
@@ -61,7 +52,7 @@ export const AIChatSessionPanel: React.FC<AIChatSessionPanelProps> = React.memo(
         snapPoints={snapPoints}
         enablePanDownToClose
         onChange={handleSheetChange}
-        animationConfigs={animationConfigs}
+        animationConfigs={spring.sheet}
         backdropComponent={renderBackdrop}
         backgroundStyle={style(sessionTokens.background)}
         handleIndicatorStyle={style('bg-slate-6 w-10')}>

--- a/src/presentation/ai-chat/components/ai-assistant/AIChatSessionPanel.tsx
+++ b/src/presentation/ai-chat/components/ai-assistant/AIChatSessionPanel.tsx
@@ -1,6 +1,10 @@
 import React, { useCallback, useMemo, useRef } from 'react';
 import { View, Text } from 'react-native';
-import BottomSheet, { BottomSheetScrollView, BottomSheetBackdrop } from '@gorhom/bottom-sheet';
+import BottomSheet, {
+  BottomSheetScrollView,
+  BottomSheetBackdrop,
+  useBottomSheetSpringConfigs,
+} from '@gorhom/bottom-sheet';
 import type { BottomSheetBackdropProps } from '@gorhom/bottom-sheet';
 import { AISessionList } from './AISessionList';
 import type { AIChatSession } from '@application/store/ai-chat/aiChatTypes';
@@ -23,6 +27,12 @@ export const AIChatSessionPanel: React.FC<AIChatSessionPanelProps> = React.memo(
     const sessionTokens = tokens.session;
     const bottomSheetRef = useRef<BottomSheet>(null);
     const snapPoints = useMemo(() => ['40%', '75%'], []);
+
+    const animationConfigs = useBottomSheetSpringConfigs({
+      mass: 1,
+      stiffness: 420,
+      damping: 80,
+    });
 
     const renderBackdrop = useCallback(
       (props: BottomSheetBackdropProps) => (
@@ -51,6 +61,7 @@ export const AIChatSessionPanel: React.FC<AIChatSessionPanelProps> = React.memo(
         snapPoints={snapPoints}
         enablePanDownToClose
         onChange={handleSheetChange}
+        animationConfigs={animationConfigs}
         backdropComponent={renderBackdrop}
         backgroundStyle={style(sessionTokens.background)}
         handleIndicatorStyle={style('bg-slate-6 w-10')}>

--- a/src/presentation/ai-chat/components/ai-assistant/AIInputField.tsx
+++ b/src/presentation/ai-chat/components/ai-assistant/AIInputField.tsx
@@ -32,7 +32,7 @@ export const AIInputField: React.FC<AIInputFieldProps> = ({ onSend, isLoading, o
 
   return (
     <Animated.View
-      layout={LinearTransition.springify().damping(20).stiffness(120)}
+      layout={LinearTransition.springify().damping(28).stiffness(200)}
       style={[
         style('px-4 py-2 border-t', inputTokens.containerBackground, inputTokens.containerBorder),
       ]}>

--- a/src/presentation/ai-chat/components/ai-assistant/AIInputField.tsx
+++ b/src/presentation/ai-chat/components/ai-assistant/AIInputField.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useCallback, useRef } from 'react';
 import { View, TextInput, Pressable } from 'react-native';
-import Animated, { LinearTransition } from 'react-native-reanimated';
+import Animated from 'react-native-reanimated';
 import { Mic, Send } from 'lucide-react-native';
+import { softLayout } from '@infrastructure/animation';
 import { useThemeColors } from '@infrastructure/theme';
 import { useAIStyles } from '@presentation/ai-chat/styles/ai-assistant';
 import type { AIInputFieldProps } from '@presentation/ai-chat/containers/ai-assistant/types';
@@ -32,7 +33,7 @@ export const AIInputField: React.FC<AIInputFieldProps> = ({ onSend, isLoading, o
 
   return (
     <Animated.View
-      layout={LinearTransition.springify().damping(28).stiffness(200)}
+      layout={softLayout()}
       style={[
         style('px-4 py-2 border-t', inputTokens.containerBackground, inputTokens.containerBorder),
       ]}>

--- a/src/presentation/ai-chat/components/ai-assistant/AIThoughtsView.tsx
+++ b/src/presentation/ai-chat/components/ai-assistant/AIThoughtsView.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { View, Text, TouchableOpacity, ScrollView } from 'react-native';
 import Animated, { useAnimatedStyle, withTiming } from 'react-native-reanimated';
 import type { UIMessage } from 'ai';
+import { timing } from '@infrastructure/animation';
 import { useAIStyles } from '@presentation/ai-chat/styles/ai-assistant';
 // Use domain type guards instead of hardcoded strings
 import { isTextPart, type MessagePart } from '@domain/types/ai-chat/parts';
@@ -82,15 +83,15 @@ export const AIThoughtsView: React.FC<AIThoughtsViewProps> = ({ message, timesta
   // This reduces re-renders caused by text content growing
   const contentAnimatedStyle = useAnimatedStyle(() => {
     return {
-      maxHeight: withTiming(isExpanded ? 320 : 0, { duration: 300 }),
-      opacity: withTiming(isExpanded ? 1 : 0, { duration: 300 }),
+      maxHeight: withTiming(isExpanded ? 320 : 0, timing.content),
+      opacity: withTiming(isExpanded ? 1 : 0, timing.content),
     };
   });
 
   // Animated style for chevron
   const chevronAnimatedStyle = useAnimatedStyle(() => {
     return {
-      transform: [{ rotate: withTiming(isExpanded ? '180deg' : '0deg', { duration: 300 }) }],
+      transform: [{ rotate: withTiming(isExpanded ? '180deg' : '0deg', timing.content) }],
     };
   });
 

--- a/src/presentation/ai-chat/containers/ai-assistant/FloatingAIAssistant.tsx
+++ b/src/presentation/ai-chat/containers/ai-assistant/FloatingAIAssistant.tsx
@@ -7,6 +7,7 @@ import Animated, {
   withSpring,
   withTiming,
 } from 'react-native-reanimated';
+import { spring, timing } from '@infrastructure/animation';
 import { useScaleAnimation, useHaptic } from '@infrastructure/utils';
 import { Sparkles } from 'lucide-react-native';
 import { AIChatInterface } from './AIChatInterface';
@@ -44,17 +45,11 @@ export const FloatingAIAssistant: React.FC<FloatingAIAssistantProps> = React.mem
         const newValue = !prev;
 
         // Animate FAB
-        fabScale.value = withSpring(newValue ? 0 : 1, {
-          damping: 28,
-          stiffness: 200,
-        });
+        fabScale.value = withSpring(newValue ? 0 : 1, spring.soft);
 
         // Animate chat interface
-        opacity.value = withTiming(newValue ? 1 : 0, { duration: 200 });
-        translateY.value = withSpring(newValue ? 0 : 100, {
-          damping: 28,
-          stiffness: 200,
-        });
+        opacity.value = withTiming(newValue ? 1 : 0, timing.fast);
+        translateY.value = withSpring(newValue ? 0 : 100, spring.soft);
 
         return newValue;
       });
@@ -72,15 +67,9 @@ export const FloatingAIAssistant: React.FC<FloatingAIAssistantProps> = React.mem
 
     const handleClose = useCallback(() => {
       setIsExpanded(false);
-      opacity.value = withTiming(0, { duration: 200 });
-      translateY.value = withSpring(100, {
-        damping: 28,
-        stiffness: 200,
-      });
-      fabScale.value = withSpring(1, {
-        damping: 28,
-        stiffness: 200,
-      });
+      opacity.value = withTiming(0, timing.fast);
+      translateY.value = withSpring(100, spring.soft);
+      fabScale.value = withSpring(1, spring.soft);
     }, [opacity, translateY, fabScale]);
 
     if (isExpanded) {

--- a/src/presentation/ai-chat/containers/ai-assistant/FloatingAIAssistant.tsx
+++ b/src/presentation/ai-chat/containers/ai-assistant/FloatingAIAssistant.tsx
@@ -7,8 +7,7 @@ import Animated, {
   withSpring,
   withTiming,
 } from 'react-native-reanimated';
-import { useScaleAnimation } from '@infrastructure/utils';
-import { useHaptic } from '@infrastructure/utils';
+import { useScaleAnimation, useHaptic } from '@infrastructure/utils';
 import { Sparkles } from 'lucide-react-native';
 import { AIChatInterface } from './AIChatInterface';
 import type { FloatingAIAssistantProps } from './types';
@@ -46,14 +45,14 @@ export const FloatingAIAssistant: React.FC<FloatingAIAssistantProps> = React.mem
 
         // Animate FAB
         fabScale.value = withSpring(newValue ? 0 : 1, {
-          damping: 15,
-          stiffness: 150,
+          damping: 28,
+          stiffness: 200,
         });
 
         // Animate chat interface
         opacity.value = withTiming(newValue ? 1 : 0, { duration: 200 });
         translateY.value = withSpring(newValue ? 0 : 100, {
-          damping: 20,
+          damping: 28,
           stiffness: 200,
         });
 
@@ -75,12 +74,12 @@ export const FloatingAIAssistant: React.FC<FloatingAIAssistantProps> = React.mem
       setIsExpanded(false);
       opacity.value = withTiming(0, { duration: 200 });
       translateY.value = withSpring(100, {
-        damping: 20,
+        damping: 28,
         stiffness: 200,
       });
       fabScale.value = withSpring(1, {
-        damping: 15,
-        stiffness: 150,
+        damping: 28,
+        stiffness: 200,
       });
     }, [opacity, translateY, fabScale]);
 

--- a/src/screens/auth/LoginScreen.tsx
+++ b/src/screens/auth/LoginScreen.tsx
@@ -15,7 +15,7 @@ import { tailwind } from '@infrastructure/theme';
 import i18n from '@infrastructure/i18n';
 import { resetAuth } from '@application/store/auth/authSlice';
 import { authActions } from '@application/store/auth/authActions';
-import { useAppDispatch, useAppSelector } from '@/hooks';
+import { useAppDispatch, useAppSelector, useThemedStyles } from '@/hooks';
 
 import {
   BottomSheetBackdrop,
@@ -39,7 +39,6 @@ import { useRefsContext } from '@infrastructure/context/RefsContext';
 import { settingsActions } from '@application/store/settings/settingsActions';
 import appLogo from '@/assets/images/logo.png';
 import { useTheme } from '@infrastructure/context/ThemeContext';
-import { useThemedStyles } from '@/hooks';
 import { SsoUtils } from '@infrastructure/utils/ssoUtils';
 
 type FormData = {
@@ -68,7 +67,7 @@ const LoginScreen = () => {
   const animationConfigs = useBottomSheetSpringConfigs({
     mass: 1,
     stiffness: 420,
-    damping: 30,
+    damping: 80,
   });
 
   const dispatch = useAppDispatch();
@@ -93,7 +92,7 @@ const LoginScreen = () => {
       if (envInstallationUrl) {
         // Try to auto-set from env to avoid forcing the user into the Configure URL screen
         // If verification fails, we'll fall back to the Configure URL screen
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+
         dispatch(settingsActions.setInstallationUrl(envInstallationUrl));
       } else {
         navigation.navigate('ConfigureURL' as never);

--- a/src/screens/auth/LoginScreen.tsx
+++ b/src/screens/auth/LoginScreen.tsx
@@ -2,11 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { Animated, Image, Pressable, StatusBar, TextInput, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
-import {
-  BottomSheetModal,
-  BottomSheetScrollView,
-  useBottomSheetSpringConfigs,
-} from '@gorhom/bottom-sheet';
+import { BottomSheetModal, BottomSheetScrollView } from '@gorhom/bottom-sheet';
+import { spring } from '@infrastructure/animation';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { EMAIL_REGEX } from '@domain/constants';

--- a/src/screens/auth/LoginScreen.tsx
+++ b/src/screens/auth/LoginScreen.tsx
@@ -61,12 +61,6 @@ const LoginScreen = () => {
 
   const { languagesModalSheetRef } = useRefsContext();
 
-  const animationConfigs = useBottomSheetSpringConfigs({
-    mass: 1,
-    stiffness: 420,
-    damping: 80,
-  });
-
   const dispatch = useAppDispatch();
   const isLoggingIn = useAppSelector(selectIsLoggingIn);
   const isLoggedIn = useAppSelector(selectLoggedIn);
@@ -352,7 +346,7 @@ const LoginScreen = () => {
         )}
         detached
         enablePanDownToClose
-        animationConfigs={animationConfigs}
+        animationConfigs={spring.sheet}
         handleStyle={themedTailwind.style('p-0 h-4 pt-[5px]')}
         style={themedTailwind.style('rounded-[26px] overflow-hidden')}
         backgroundStyle={themedTailwind.style('bg-solid-1')}

--- a/src/screens/chat-screen/components/audio-recorder/AudioRecorder.tsx
+++ b/src/screens/chat-screen/components/audio-recorder/AudioRecorder.tsx
@@ -226,8 +226,8 @@ export const AudioRecorder = ({
 
   return (
     <Animated.View
-      exiting={SlideOutDown.damping(24).stiffness(180)}
-      entering={SlideInDown.damping(24).stiffness(180)}
+      exiting={SlideOutDown.damping(80).stiffness(180)}
+      entering={SlideInDown.damping(80).stiffness(180)}
       style={tailwind.style(
         'px-1 flex flex-row items-center overflow-hidden',
         `max-h-[${TEXT_INPUT_CONTAINER_HEIGHT}px]`,

--- a/src/screens/chat-screen/components/audio-recorder/AudioRecorder.tsx
+++ b/src/screens/chat-screen/components/audio-recorder/AudioRecorder.tsx
@@ -226,8 +226,8 @@ export const AudioRecorder = ({
 
   return (
     <Animated.View
-      exiting={SlideOutDown.damping(80).stiffness(180)}
-      entering={SlideInDown.damping(80).stiffness(180)}
+      exiting={SlideOutDown.springify().damping(80).stiffness(240)}
+      entering={SlideInDown.springify().damping(80).stiffness(240)}
       style={tailwind.style(
         'px-1 flex flex-row items-center overflow-hidden',
         `max-h-[${TEXT_INPUT_CONTAINER_HEIGHT}px]`,

--- a/src/screens/chat-screen/components/audio-recorder/AudioRecorder.tsx
+++ b/src/screens/chat-screen/components/audio-recorder/AudioRecorder.tsx
@@ -4,12 +4,13 @@ import AudioRecorderPlayer, {
   RecordBackType,
   AVEncodingOption,
 } from 'react-native-audio-recorder-player';
-import Animated, { SlideInDown, SlideOutDown } from 'react-native-reanimated';
+import Animated from 'react-native-reanimated';
 import isUndefined from 'lodash/isUndefined';
 import * as Sentry from '@sentry/react-native';
 import ReactNativeBlobUtil from 'react-native-blob-util';
 import { Trash } from '@/svg-icons/common/Trash';
 
+import { snappySlideInDown, snappySlideOutDown } from '@infrastructure/animation';
 import { TEXT_INPUT_CONTAINER_HEIGHT } from '@domain/constants';
 import { useChatWindowContext } from '@infrastructure/context';
 import i18n from '@infrastructure/i18n';
@@ -226,8 +227,8 @@ export const AudioRecorder = ({
 
   return (
     <Animated.View
-      exiting={SlideOutDown.springify().damping(80).stiffness(240)}
-      entering={SlideInDown.springify().damping(80).stiffness(240)}
+      exiting={snappySlideOutDown()}
+      entering={snappySlideInDown()}
       style={tailwind.style(
         'px-1 flex flex-row items-center overflow-hidden',
         `max-h-[${TEXT_INPUT_CONTAINER_HEIGHT}px]`,

--- a/src/screens/chat-screen/components/chat-header/ChatHeader.tsx
+++ b/src/screens/chat-screen/components/chat-header/ChatHeader.tsx
@@ -58,12 +58,6 @@ export const ChatHeader = ({
   const { colors } = useThemeColors();
   const { slaEventsSheetRef } = useRefsContext();
 
-  const animationConfigs = useBottomSheetSpringConfigs({
-    mass: 1,
-    stiffness: 420,
-    damping: 80,
-  });
-
   const toggleSlaEventsSheet = () => {
     if (slaEvents?.length) {
       Keyboard.dismiss();
@@ -143,7 +137,7 @@ export const ChatHeader = ({
         backdropComponent={BottomSheetBackdrop}
         handleIndicatorStyle={tailwind.style('overflow-hidden bg-blackA-A6 w-8 h-1 rounded-[11px]')}
         enablePanDownToClose
-        animationConfigs={animationConfigs}
+        animationConfigs={spring.sheet}
         handleStyle={tailwind.style('p-0 h-4 pt-[5px]')}
         style={tailwind.style('rounded-[26px] overflow-hidden')}
         snapPoints={['36%']}>

--- a/src/screens/chat-screen/components/chat-header/ChatHeader.tsx
+++ b/src/screens/chat-screen/components/chat-header/ChatHeader.tsx
@@ -60,7 +60,7 @@ export const ChatHeader = ({
   const animationConfigs = useBottomSheetSpringConfigs({
     mass: 1,
     stiffness: 420,
-    damping: 30,
+    damping: 80,
   });
 
   const toggleSlaEventsSheet = () => {

--- a/src/screens/chat-screen/components/chat-header/ChatHeader.tsx
+++ b/src/screens/chat-screen/components/chat-header/ChatHeader.tsx
@@ -5,13 +5,12 @@ import Animated from 'react-native-reanimated';
 import { ChevronLeft } from '@/svg-icons/common/ChevronLeft';
 import { Overflow } from '@/svg-icons/common/Overflow';
 
-import { Avatar, Icon } from '@infrastructure/ui';
+import { Avatar, Icon, BottomSheetBackdrop, BottomSheetWrapper } from '@infrastructure/ui';
 import { InboxIndicator } from '@infrastructure/ui/list-components';
 import { Inbox } from '@domain/types/Inbox';
 import { ConversationAdditionalAttributes } from '@domain/types/Conversation';
 import { /* OpenIcon, ResolvedIcon, */ SLAIcon } from '@/svg-icons';
 import { AIHeaderButton } from '@infrastructure/ui/ai-status/AIHeaderButton';
-import { BottomSheetBackdrop, BottomSheetWrapper } from '@infrastructure/ui';
 import { tailwind, useThemeColors } from '@infrastructure/theme';
 import { useThemedStyles } from '@infrastructure/hooks';
 import { ChatDropdownMenu, DashboardList } from './DropdownMenu';
@@ -73,7 +72,7 @@ export const ChatHeader = ({
 
   return (
     <Animated.View style={[themedTailwind.style('border-b-[1px] border-b-slate-6')]}>
-      <Animated.View style={tailwind.style('flex flex-row justify-between items-center px-4 py-2')}>
+      <Animated.View style={tailwind.style('flex flex-row justify-between items-center px-4 py-3')}>
         <Animated.View style={tailwind.style('flex-1 flex-row gap-2 items-center justify-center')}>
           <Pressable
             hitSlop={8}

--- a/src/screens/chat-screen/components/chat-header/ChatHeader.tsx
+++ b/src/screens/chat-screen/components/chat-header/ChatHeader.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ImageSourcePropType, Keyboard, Platform, Pressable } from 'react-native';
-import { BottomSheetModal, useBottomSheetSpringConfigs } from '@gorhom/bottom-sheet';
+import { BottomSheetModal } from '@gorhom/bottom-sheet';
+import { spring } from '@infrastructure/animation';
 import Animated from 'react-native-reanimated';
 import { ChevronLeft } from '@/svg-icons/common/ChevronLeft';
 import { Overflow } from '@/svg-icons/common/Overflow';

--- a/src/screens/chat-screen/components/chat-header/DropdownMenu.tsx
+++ b/src/screens/chat-screen/components/chat-header/DropdownMenu.tsx
@@ -90,12 +90,6 @@ export const ChatDropdownMenu = (props: PropsWithChildren<ChatDropdownMenuProps>
 
   const { bottom } = useSafeAreaInsets();
 
-  const animationConfigs = useBottomSheetSpringConfigs({
-    mass: 1,
-    stiffness: 420,
-    damping: 80,
-  });
-
   const renderBackDrop = useCallback(
     (backdropProps: BottomSheetBackdropProps) => (
       <DropdownMenuBottomSheetBackdrop
@@ -124,7 +118,7 @@ export const ChatDropdownMenu = (props: PropsWithChildren<ChatDropdownMenuProps>
           backgroundStyle={themedTailwind.style('bg-solid-1')}
           detached
           bottomInset={bottom === 0 ? 12 : bottom}
-          animationConfigs={animationConfigs}
+          animationConfigs={spring.sheet}
           enablePanDownToClose
           snapPoints={[dropdownMenuList.length * 44 + 4 + 37]}>
           <BottomSheetWrapper>

--- a/src/screens/chat-screen/components/chat-header/DropdownMenu.tsx
+++ b/src/screens/chat-screen/components/chat-header/DropdownMenu.tsx
@@ -2,11 +2,8 @@ import React, { forwardRef, PropsWithChildren, useCallback, useRef, type JSX } f
 import { Platform, Pressable, View } from 'react-native';
 import Animated, { interpolate, useAnimatedStyle } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import {
-  BottomSheetBackdropProps,
-  BottomSheetModal,
-  useBottomSheetSpringConfigs,
-} from '@gorhom/bottom-sheet';
+import { BottomSheetBackdropProps, BottomSheetModal } from '@gorhom/bottom-sheet';
+import { spring } from '@infrastructure/animation';
 import * as DropdownMenu from 'zeego/dropdown-menu';
 
 import { BottomSheetHeader, BottomSheetWrapper } from '@infrastructure/ui';

--- a/src/screens/chat-screen/components/chat-header/DropdownMenu.tsx
+++ b/src/screens/chat-screen/components/chat-header/DropdownMenu.tsx
@@ -96,7 +96,7 @@ export const ChatDropdownMenu = (props: PropsWithChildren<ChatDropdownMenuProps>
   const animationConfigs = useBottomSheetSpringConfigs({
     mass: 1,
     stiffness: 420,
-    damping: 30,
+    damping: 80,
   });
 
   const renderBackDrop = useCallback(

--- a/src/screens/chat-screen/components/macros/MacroDetails.tsx
+++ b/src/screens/chat-screen/components/macros/MacroDetails.tsx
@@ -79,7 +79,7 @@ const MacroDetails = ({ macro, onBack, onClose }: MacroDetailsProps) => {
   }, []);
 
   return (
-    <Animated.View entering={FadeIn.duration(300).springify()} style={tailwind.style('flex-1')}>
+    <Animated.View entering={FadeIn.duration(300)} style={tailwind.style('flex-1')}>
       <View style={tailwind.style('flex-row items-center p-4')}>
         <Pressable onPress={onBack} style={tailwind.style('flex-1 flex-row items-center')}>
           <View style={tailwind.style('mr-1')}>

--- a/src/screens/chat-screen/components/macros/MacroDetails.tsx
+++ b/src/screens/chat-screen/components/macros/MacroDetails.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react';
 import { Pressable, View } from 'react-native';
-import Animated, { FadeIn } from 'react-native-reanimated';
+import Animated from 'react-native-reanimated';
+import { contentFadeInLinear } from '@infrastructure/animation';
 import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
 import { ChevronLeft } from '@/svg-icons/common/ChevronLeft';
 
@@ -79,7 +80,7 @@ const MacroDetails = ({ macro, onBack, onClose }: MacroDetailsProps) => {
   }, []);
 
   return (
-    <Animated.View entering={FadeIn.duration(300)} style={tailwind.style('flex-1')}>
+    <Animated.View entering={contentFadeInLinear()} style={tailwind.style('flex-1')}>
       <View style={tailwind.style('flex-row items-center p-4')}>
         <Pressable onPress={onBack} style={tailwind.style('flex-1 flex-row items-center')}>
           <View style={tailwind.style('mr-1')}>

--- a/src/screens/chat-screen/components/macros/MacrosList.tsx
+++ b/src/screens/chat-screen/components/macros/MacrosList.tsx
@@ -1,11 +1,8 @@
 import React, { useState } from 'react';
 import { View } from 'react-native';
 import Animated from 'react-native-reanimated';
-import {
-  BottomSheetModal,
-  BottomSheetScrollView,
-  useBottomSheetSpringConfigs,
-} from '@gorhom/bottom-sheet';
+import { BottomSheetModal, BottomSheetScrollView } from '@gorhom/bottom-sheet';
+import { spring } from '@infrastructure/animation';
 
 import { BottomSheetBackdrop } from '@infrastructure/ui';
 import i18n from '@infrastructure/i18n';
@@ -38,12 +35,6 @@ export const MacrosList = ({ conversationId }: { conversationId: number }) => {
 
   const { macrosListSheetRef } = useRefsContext();
 
-  const animationConfigs = useBottomSheetSpringConfigs({
-    mass: 1,
-    stiffness: 420,
-    damping: 80,
-  });
-
   return (
     <Animated.View>
       <BottomSheetModal
@@ -55,7 +46,7 @@ export const MacrosList = ({ conversationId }: { conversationId: number }) => {
         enablePanDownToClose
         snapPoints={['75%']}
         enableDynamicSizing={false}
-        animationConfigs={animationConfigs}>
+        animationConfigs={spring.sheet}>
         <MacroProvider conversationId={conversationId} onClose={onClose}>
           <Animated.View style={tailwind.style('flex-1')}>
             {selectedMacro ? (

--- a/src/screens/chat-screen/components/macros/MacrosList.tsx
+++ b/src/screens/chat-screen/components/macros/MacrosList.tsx
@@ -1,7 +1,11 @@
 import React, { useState } from 'react';
 import { View } from 'react-native';
 import Animated from 'react-native-reanimated';
-import { BottomSheetModal, BottomSheetScrollView } from '@gorhom/bottom-sheet';
+import {
+  BottomSheetModal,
+  BottomSheetScrollView,
+  useBottomSheetSpringConfigs,
+} from '@gorhom/bottom-sheet';
 
 import { BottomSheetBackdrop } from '@infrastructure/ui';
 import i18n from '@infrastructure/i18n';
@@ -34,6 +38,12 @@ export const MacrosList = ({ conversationId }: { conversationId: number }) => {
 
   const { macrosListSheetRef } = useRefsContext();
 
+  const animationConfigs = useBottomSheetSpringConfigs({
+    mass: 1,
+    stiffness: 420,
+    damping: 80,
+  });
+
   return (
     <Animated.View>
       <BottomSheetModal
@@ -44,7 +54,8 @@ export const MacrosList = ({ conversationId }: { conversationId: number }) => {
         style={tailwind.style('rounded-t-[26px] overflow-hidden')}
         enablePanDownToClose
         snapPoints={['75%']}
-        enableDynamicSizing={false}>
+        enableDynamicSizing={false}
+        animationConfigs={animationConfigs}>
         <MacroProvider conversationId={conversationId} onClose={onClose}>
           <Animated.View style={tailwind.style('flex-1')}>
             {selectedMacro ? (

--- a/src/screens/chat-screen/components/message-components/ActivityBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/ActivityBubble.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import Animated from 'react-native-reanimated';
 
-import { tailwind } from '@infrastructure/theme';
 import { messageTimestamp } from '@infrastructure/utils/dateTimeUtils';
 import { localizeActivityMessage } from '@infrastructure/utils/activityMessageUtils';
+import { useThemedStyles } from '@/hooks';
 
 type ActivityBubbleProps = {
   text: string;
@@ -13,14 +13,20 @@ type ActivityBubbleProps = {
 export const ActivityBubble = (props: ActivityBubbleProps) => {
   const { text, timeStamp } = props;
   const localizedText = localizeActivityMessage(text);
+  const themedTailwind = useThemedStyles();
   return (
-    <Animated.View style={tailwind.style('flex flex-row flex-wrap justify-center py-1 px-10')}>
-      <Animated.Text
-        style={tailwind.style(
-          'text-cxs font-inter-420-20 tracking-[0.32px] leading-[18px] text-slate-11 text-center',
+    <Animated.View style={themedTailwind.style('flex flex-row justify-center py-2 px-6')}>
+      <Animated.View
+        style={themedTailwind.style(
+          'flex flex-row items-center bg-slate-3 rounded-full px-3 py-1.5',
         )}>
-        {localizedText} {messageTimestamp(timeStamp)}
-      </Animated.Text>
+        <Animated.Text
+          style={themedTailwind.style(
+            'text-cxs font-inter-420-20 tracking-[0.32px] leading-[18px] text-slate-11 text-center',
+          )}>
+          {localizedText} {messageTimestamp(timeStamp)}
+        </Animated.Text>
+      </Animated.View>
     </Animated.View>
   );
 };

--- a/src/screens/chat-screen/components/message-components/AttachedMedia.tsx
+++ b/src/screens/chat-screen/components/message-components/AttachedMedia.tsx
@@ -74,8 +74,8 @@ const AttachedImage = (props: AttachedImageProps) => {
 
   return (
     <Animated.View
-      entering={SlideInDown.springify().damping(38).stiffness(240)}
-      exiting={SlideOutDown.springify().damping(38).stiffness(240)}
+      entering={SlideInDown.springify().damping(80).stiffness(240)}
+      exiting={SlideOutDown.springify().damping(80).stiffness(240)}
       style={tailwind.style('pr-3 relative')}>
       <Animated.View
         layout={LinearTransition.springify().damping(28).stiffness(200)}
@@ -126,8 +126,8 @@ const AttachedVideo = (props: AttachedVideoProps) => {
 
   return (
     <Animated.View
-      entering={SlideInDown.springify().damping(38).stiffness(240)}
-      exiting={SlideOutDown.springify().damping(38).stiffness(240)}
+      entering={SlideInDown.springify().damping(80).stiffness(240)}
+      exiting={SlideOutDown.springify().damping(80).stiffness(240)}
       style={tailwind.style('pr-3 relative')}>
       <Animated.View
         layout={LinearTransition.springify().damping(28).stiffness(200)}
@@ -200,8 +200,8 @@ const AttachedFile = (props: AttachedFileProps) => {
 
   return (
     <Animated.View
-      entering={SlideInDown.springify().damping(38).stiffness(240)}
-      exiting={SlideOutDown.springify().damping(38).stiffness(240)}
+      entering={SlideInDown.springify().damping(80).stiffness(240)}
+      exiting={SlideOutDown.springify().damping(80).stiffness(240)}
       style={tailwind.style('pr-3 relative')}>
       <Animated.View
         layout={LinearTransition.springify().damping(28).stiffness(200)}
@@ -261,8 +261,8 @@ export const AttachedMedia = () => {
     <Animated.View style={tailwind.style('py-4')}>
       <Animated.FlatList
         itemLayoutAnimation={LinearTransition.springify().damping(28).stiffness(200)}
-        entering={SlideInUp.springify().damping(38).stiffness(240)}
-        exiting={SlideOutDown.springify().damping(38).stiffness(240)}
+        entering={SlideInUp.springify().damping(80).stiffness(240)}
+        exiting={SlideOutDown.springify().damping(80).stiffness(240)}
         style={tailwind.style('px-4 pr-12')}
         horizontal
         showsHorizontalScrollIndicator={false}

--- a/src/screens/chat-screen/components/message-components/AttachedMedia.tsx
+++ b/src/screens/chat-screen/components/message-components/AttachedMedia.tsx
@@ -1,16 +1,12 @@
 import React from 'react';
 import { Pressable, StyleSheet } from 'react-native';
 import { PickedAsset } from '@domain/types';
-import Animated, {
-  LinearTransition,
-  SlideInDown,
-  SlideInUp,
-  SlideOutDown,
-} from 'react-native-reanimated';
+import Animated, { SlideInDown, SlideInUp, SlideOutDown } from 'react-native-reanimated';
 import Svg, { Path } from 'react-native-svg';
 import { useVideoPlayer, VideoView } from 'expo-video';
 import { Image } from 'expo-image';
 
+import { softLayout } from '@infrastructure/animation';
 import { AttachFileIcon } from '@/svg-icons';
 import { tailwind, useThemeColors } from '@infrastructure/theme';
 import { useScaleAnimation } from '@infrastructure/utils';
@@ -78,7 +74,7 @@ const AttachedImage = (props: AttachedImageProps) => {
       exiting={SlideOutDown.springify().damping(80).stiffness(240)}
       style={tailwind.style('pr-3 relative')}>
       <Animated.View
-        layout={LinearTransition.springify().damping(28).stiffness(200)}
+        layout={softLayout()}
         style={tailwind.style(
           'h-23 w-[137px] rounded-lg',
           index === attachmentsLength - 1 ? 'mr-4' : '',
@@ -130,7 +126,7 @@ const AttachedVideo = (props: AttachedVideoProps) => {
       exiting={SlideOutDown.springify().damping(80).stiffness(240)}
       style={tailwind.style('pr-3 relative')}>
       <Animated.View
-        layout={LinearTransition.springify().damping(28).stiffness(200)}
+        layout={softLayout()}
         style={tailwind.style(
           'h-23 w-[137px] rounded-lg',
           index === attachmentsLength - 1 ? 'mr-4' : '',
@@ -204,7 +200,7 @@ const AttachedFile = (props: AttachedFileProps) => {
       exiting={SlideOutDown.springify().damping(80).stiffness(240)}
       style={tailwind.style('pr-3 relative')}>
       <Animated.View
-        layout={LinearTransition.springify().damping(28).stiffness(200)}
+        layout={softLayout()}
         style={tailwind.style(
           'h-23 w-[137px] rounded-lg items-center justify-center',
           index === attachmentsLength - 1 ? 'mr-4' : '',
@@ -260,7 +256,7 @@ export const AttachedMedia = () => {
   return attachments.length > 0 ? (
     <Animated.View style={tailwind.style('py-4')}>
       <Animated.FlatList
-        itemLayoutAnimation={LinearTransition.springify().damping(28).stiffness(200)}
+        itemLayoutAnimation={softLayout()}
         entering={SlideInUp.springify().damping(80).stiffness(240)}
         exiting={SlideOutDown.springify().damping(80).stiffness(240)}
         style={tailwind.style('px-4 pr-12')}

--- a/src/screens/chat-screen/components/message-components/AttachedMedia.tsx
+++ b/src/screens/chat-screen/components/message-components/AttachedMedia.tsx
@@ -74,11 +74,11 @@ const AttachedImage = (props: AttachedImageProps) => {
 
   return (
     <Animated.View
-      entering={SlideInDown.springify().damping(20).stiffness(120)}
-      exiting={SlideOutDown.springify().damping(20).stiffness(120)}
+      entering={SlideInDown.springify().damping(38).stiffness(240)}
+      exiting={SlideOutDown.springify().damping(38).stiffness(240)}
       style={tailwind.style('pr-3 relative')}>
       <Animated.View
-        layout={LinearTransition.springify()}
+        layout={LinearTransition.springify().damping(28).stiffness(200)}
         style={tailwind.style(
           'h-23 w-[137px] rounded-lg',
           index === attachmentsLength - 1 ? 'mr-4' : '',
@@ -126,11 +126,11 @@ const AttachedVideo = (props: AttachedVideoProps) => {
 
   return (
     <Animated.View
-      entering={SlideInDown.springify().damping(20).stiffness(120)}
-      exiting={SlideOutDown.springify().damping(20).stiffness(120)}
+      entering={SlideInDown.springify().damping(38).stiffness(240)}
+      exiting={SlideOutDown.springify().damping(38).stiffness(240)}
       style={tailwind.style('pr-3 relative')}>
       <Animated.View
-        layout={LinearTransition.springify()}
+        layout={LinearTransition.springify().damping(28).stiffness(200)}
         style={tailwind.style(
           'h-23 w-[137px] rounded-lg',
           index === attachmentsLength - 1 ? 'mr-4' : '',
@@ -166,7 +166,6 @@ const AttachedVideo = (props: AttachedVideoProps) => {
             tailwind.style('rounded-lg'),
             { transform: [{ rotateY: '180deg' }] },
           ]}
-          // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
           source={require('../../../../assets/local/ImageCellTimeStampOverlay.png')}
         />
         <Animated.View
@@ -201,11 +200,11 @@ const AttachedFile = (props: AttachedFileProps) => {
 
   return (
     <Animated.View
-      entering={SlideInDown.springify().damping(20).stiffness(120)}
-      exiting={SlideOutDown.springify().damping(20).stiffness(120)}
+      entering={SlideInDown.springify().damping(38).stiffness(240)}
+      exiting={SlideOutDown.springify().damping(38).stiffness(240)}
       style={tailwind.style('pr-3 relative')}>
       <Animated.View
-        layout={LinearTransition.springify()}
+        layout={LinearTransition.springify().damping(28).stiffness(200)}
         style={tailwind.style(
           'h-23 w-[137px] rounded-lg items-center justify-center',
           index === attachmentsLength - 1 ? 'mr-4' : '',
@@ -261,9 +260,9 @@ export const AttachedMedia = () => {
   return attachments.length > 0 ? (
     <Animated.View style={tailwind.style('py-4')}>
       <Animated.FlatList
-        itemLayoutAnimation={LinearTransition.springify().damping(25).stiffness(200)}
-        entering={SlideInUp}
-        exiting={SlideOutDown}
+        itemLayoutAnimation={LinearTransition.springify().damping(28).stiffness(200)}
+        entering={SlideInUp.springify().damping(38).stiffness(240)}
+        exiting={SlideOutDown.springify().damping(38).stiffness(240)}
         style={tailwind.style('px-4 pr-12')}
         horizontal
         showsHorizontalScrollIndicator={false}

--- a/src/screens/chat-screen/components/message-components/AttachedMedia.tsx
+++ b/src/screens/chat-screen/components/message-components/AttachedMedia.tsx
@@ -1,12 +1,17 @@
 import React from 'react';
 import { Pressable, StyleSheet } from 'react-native';
 import { PickedAsset } from '@domain/types';
-import Animated, { SlideInDown, SlideInUp, SlideOutDown } from 'react-native-reanimated';
+import Animated from 'react-native-reanimated';
 import Svg, { Path } from 'react-native-svg';
 import { useVideoPlayer, VideoView } from 'expo-video';
 import { Image } from 'expo-image';
 
-import { softLayout } from '@infrastructure/animation';
+import {
+  softLayout,
+  snappySlideInDown,
+  snappySlideInUp,
+  snappySlideOutDown,
+} from '@infrastructure/animation';
 import { AttachFileIcon } from '@/svg-icons';
 import { tailwind, useThemeColors } from '@infrastructure/theme';
 import { useScaleAnimation } from '@infrastructure/utils';
@@ -70,8 +75,8 @@ const AttachedImage = (props: AttachedImageProps) => {
 
   return (
     <Animated.View
-      entering={SlideInDown.springify().damping(80).stiffness(240)}
-      exiting={SlideOutDown.springify().damping(80).stiffness(240)}
+      entering={snappySlideInDown()}
+      exiting={snappySlideOutDown()}
       style={tailwind.style('pr-3 relative')}>
       <Animated.View
         layout={softLayout()}
@@ -122,8 +127,8 @@ const AttachedVideo = (props: AttachedVideoProps) => {
 
   return (
     <Animated.View
-      entering={SlideInDown.springify().damping(80).stiffness(240)}
-      exiting={SlideOutDown.springify().damping(80).stiffness(240)}
+      entering={snappySlideInDown()}
+      exiting={snappySlideOutDown()}
       style={tailwind.style('pr-3 relative')}>
       <Animated.View
         layout={softLayout()}
@@ -196,8 +201,8 @@ const AttachedFile = (props: AttachedFileProps) => {
 
   return (
     <Animated.View
-      entering={SlideInDown.springify().damping(80).stiffness(240)}
-      exiting={SlideOutDown.springify().damping(80).stiffness(240)}
+      entering={snappySlideInDown()}
+      exiting={snappySlideOutDown()}
       style={tailwind.style('pr-3 relative')}>
       <Animated.View
         layout={softLayout()}
@@ -257,8 +262,8 @@ export const AttachedMedia = () => {
     <Animated.View style={tailwind.style('py-4')}>
       <Animated.FlatList
         itemLayoutAnimation={softLayout()}
-        entering={SlideInUp.springify().damping(80).stiffness(240)}
-        exiting={SlideOutDown.springify().damping(80).stiffness(240)}
+        entering={snappySlideInUp()}
+        exiting={snappySlideOutDown()}
         style={tailwind.style('px-4 pr-12')}
         horizontal
         showsHorizontalScrollIndicator={false}

--- a/src/screens/chat-screen/components/message-components/AudioCell.tsx
+++ b/src/screens/chat-screen/components/message-components/AudioCell.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { Pressable, Text, View } from 'react-native';
 import { PlayBackType } from 'react-native-audio-recorder-player';
-import Animated, { Easing, FadeIn, FadeOut, useSharedValue } from 'react-native-reanimated';
+import Animated, { FadeIn, FadeOut, useSharedValue } from 'react-native-reanimated';
+import { contentFadeIn } from '@infrastructure/animation';
 import Svg, { Path, Rect } from 'react-native-svg';
 
 import {
@@ -202,7 +203,7 @@ export const AudioCell: React.FC<AudioCellProps> = props => {
 
   return (
     <Animated.View
-      entering={FadeIn.duration(300).easing(Easing.ease)}
+      entering={contentFadeIn()}
       style={tailwind.style(
         'w-full my-[1px]',
         isIncoming && 'items-start',

--- a/src/screens/chat-screen/components/message-components/CommandOptionsMenu.tsx
+++ b/src/screens/chat-screen/components/message-components/CommandOptionsMenu.tsx
@@ -8,12 +8,13 @@ import {
   type DocumentPickerResponse,
 } from '@react-native-documents/picker';
 import * as ImagePicker from 'expo-image-picker';
-import Animated, { SlideInDown, SlideOutDown } from 'react-native-reanimated';
+import Animated from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useAppDispatch } from '@/hooks';
 import { updateAttachments } from '@application/store/conversation/sendMessageSlice';
 import { useRefsContext } from '@infrastructure/context';
 import { AttachFileIcon, CameraIcon, MacrosIcon, PhotosIcon } from '@/svg-icons';
+import { snappySlideInDown, snappySlideOutDown } from '@infrastructure/animation';
 import { tailwind } from '@infrastructure/theme';
 import { useHaptic, useScaleAnimation, processImageForUpload } from '@infrastructure/utils';
 import { Icon } from '@infrastructure/ui/common';
@@ -232,8 +233,8 @@ export const CommandOptionsMenu = () => {
     : 175 + (bottom === 0 ? 16 : bottom);
   return (
     <Animated.View
-      entering={SlideInDown.springify().damping(80).stiffness(240)}
-      exiting={SlideOutDown.springify().damping(80).stiffness(240)}
+      entering={snappySlideInDown()}
+      exiting={snappySlideOutDown()}
       style={tailwind.style('mx-1 pt-2 items-start', `h-[${containerHeight}px]`)}>
       {ADD_MENU_OPTIONS.map((menuOption, index) => {
         return <MenuOption key={menuOption.key} {...{ menuOption, index }} />;

--- a/src/screens/chat-screen/components/message-components/CommandOptionsMenu.tsx
+++ b/src/screens/chat-screen/components/message-components/CommandOptionsMenu.tsx
@@ -15,7 +15,7 @@ import { updateAttachments } from '@application/store/conversation/sendMessageSl
 import { useRefsContext } from '@infrastructure/context';
 import { AttachFileIcon, CameraIcon, MacrosIcon, PhotosIcon } from '@/svg-icons';
 import { tailwind } from '@infrastructure/theme';
-import { useHaptic, useScaleAnimation } from '@infrastructure/utils';
+import { useHaptic, useScaleAnimation, processImageForUpload } from '@infrastructure/utils';
 import { Icon } from '@infrastructure/ui/common';
 import { MAXIMUM_FILE_UPLOAD_SIZE } from '@domain/constants';
 import i18n from '@infrastructure/i18n';
@@ -47,7 +47,9 @@ export const handleOpenPhotosLibrary = async (dispatch: AppDispatch) => {
     // User cancelled
   } else if (pickedAssets.assets && pickedAssets.assets.length > 0) {
     for (const asset of pickedAssets.assets) {
-      validateFileAndSetAttachments(dispatch, mapExpoAsset(asset));
+      const mapped = mapExpoAsset(asset);
+      const processed = await processImageForUpload(mapped);
+      validateFileAndSetAttachments(dispatch, processed);
     }
   }
 };
@@ -80,7 +82,9 @@ const handleLaunchCamera = async (dispatch: AppDispatch) => {
   });
   if (!imageResult.canceled && imageResult.assets && imageResult.assets.length > 0) {
     const asset = imageResult.assets[0];
-    validateFileAndSetAttachments(dispatch, mapExpoAsset(asset));
+    const mapped = mapExpoAsset(asset);
+    const processed = await processImageForUpload(mapped);
+    validateFileAndSetAttachments(dispatch, processed);
   }
 };
 
@@ -125,7 +129,8 @@ const handleAttachFile = async (dispatch: AppDispatch) => {
     });
     // TODO: Support multiple files
     const file = mapObject(result[0])[0];
-    validateFileAndSetAttachments(dispatch, file);
+    const processed = await processImageForUpload(file);
+    validateFileAndSetAttachments(dispatch, processed);
   } catch (err) {
     if (isErrorWithCode(err) && err.code === errorCodes.OPERATION_CANCELED) {
       // User cancelled the picker

--- a/src/screens/chat-screen/components/message-components/CommandOptionsMenu.tsx
+++ b/src/screens/chat-screen/components/message-components/CommandOptionsMenu.tsx
@@ -232,8 +232,8 @@ export const CommandOptionsMenu = () => {
     : 175 + (bottom === 0 ? 16 : bottom);
   return (
     <Animated.View
-      entering={SlideInDown.springify().damping(38).stiffness(240)}
-      exiting={SlideOutDown.springify().damping(38).stiffness(240)}
+      entering={SlideInDown.springify().damping(80).stiffness(240)}
+      exiting={SlideOutDown.springify().damping(80).stiffness(240)}
       style={tailwind.style('mx-1 pt-2 items-start', `h-[${containerHeight}px]`)}>
       {ADD_MENU_OPTIONS.map((menuOption, index) => {
         return <MenuOption key={menuOption.key} {...{ menuOption, index }} />;

--- a/src/screens/chat-screen/components/message-components/ComposedCell.tsx
+++ b/src/screens/chat-screen/components/message-components/ComposedCell.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 import { Text, Dimensions } from 'react-native';
-import Animated, { FadeIn } from 'react-native-reanimated';
+import Animated from 'react-native-reanimated';
+import { slowFadeIn } from '@infrastructure/animation';
 
 import { FileErrorIcon, LockIcon } from '@/svg-icons';
 import { tailwind } from '@infrastructure/theme';
@@ -10,7 +11,7 @@ import { Avatar, Icon } from '@infrastructure/ui';
 import { MarkdownDisplay } from './MarkdownDisplay';
 import { MenuOption, MessageMenu } from '../message-menu';
 import { ReplyMessageCell } from './ReplyMessageCell';
-import { INBOX_TYPES, MESSAGE_TYPES, TEXT_MAX_WIDTH } from '@domain/constants';
+import { INBOX_TYPES, MESSAGE_TYPES, TEXT_MAX_WIDTH, ATTACHMENT_TYPES } from '@domain/constants';
 
 import { AudioPlayer } from './AudioCell';
 import { FilePreview } from './FileCell';
@@ -20,7 +21,6 @@ import { DeliveryStatus } from './DeliveryStatus';
 import { useAppSelector } from '@/hooks';
 import { useChatWindowContext } from '@infrastructure/context';
 import { getMessagesByConversationId } from '@application/store/conversation/conversationSelectors';
-import { ATTACHMENT_TYPES } from '@domain/constants';
 import i18n from '@infrastructure/i18n';
 
 type ComposedCellProps = {
@@ -76,7 +76,7 @@ export const ComposedCell = (props: ComposedCellProps) => {
 
   return (
     <Animated.View
-      entering={FadeIn.duration(350)}
+      entering={slowFadeIn()}
       style={tailwind.style(
         'my-[1px]',
         isIncoming && 'items-start',

--- a/src/screens/chat-screen/components/message-components/DeliveryStatus.tsx
+++ b/src/screens/chat-screen/components/message-components/DeliveryStatus.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Pressable } from 'react-native';
-import { BottomSheetModal, useBottomSheetSpringConfigs } from '@gorhom/bottom-sheet';
+import { BottomSheetModal } from '@gorhom/bottom-sheet';
+import { spring } from '@infrastructure/animation';
 import { CheckCheck, Clock } from 'lucide-react-native';
 import { TickIcon } from '@/svg-icons/common/TickIcon';
 
@@ -60,12 +61,6 @@ export const DeliveryStatus = (props: DeliveryStatusProps) => {
   const shouldShowStatusIndicator =
     (messageType === MESSAGE_TYPES.OUTGOING || isTemplate) && !isPrivate;
   const isALineChannel = channel === INBOX_TYPES.LINE;
-
-  const animationConfigs = useBottomSheetSpringConfigs({
-    mass: 1,
-    stiffness: 420,
-    damping: 80,
-  });
 
   const showSentIndicator = () => {
     if (!shouldShowStatusIndicator) {
@@ -151,7 +146,7 @@ export const DeliveryStatus = (props: DeliveryStatusProps) => {
             'overflow-hidden bg-blackA-A6 w-8 h-1 rounded-[11px]',
           )}
           enablePanDownToClose
-          animationConfigs={animationConfigs}
+          animationConfigs={spring.sheet}
           handleStyle={tailwind.style('p-0 h-4 pt-[5px]')}
           style={tailwind.style('rounded-[26px] overflow-hidden')}
           snapPoints={['15']}>

--- a/src/screens/chat-screen/components/message-components/DeliveryStatus.tsx
+++ b/src/screens/chat-screen/components/message-components/DeliveryStatus.tsx
@@ -8,8 +8,7 @@ import { BottomSheetBackdrop, BottomSheetWrapper } from '@infrastructure/ui';
 import { tailwind, useThemeColors } from '@infrastructure/theme';
 import { WarningIcon } from '@/svg-icons';
 import { Icon } from '@infrastructure/ui/common';
-import { MessageStatus, MessageType } from '@domain/types';
-import { Channel } from '@domain/types';
+import { MessageStatus, MessageType, Channel } from '@domain/types';
 import { INBOX_TYPES, MESSAGE_TYPES, MESSAGE_STATUS } from '@domain/constants';
 import { ErrorInformation } from './ErrorInformation';
 import { useRefsContext } from '@infrastructure/context';
@@ -65,7 +64,7 @@ export const DeliveryStatus = (props: DeliveryStatusProps) => {
   const animationConfigs = useBottomSheetSpringConfigs({
     mass: 1,
     stiffness: 420,
-    damping: 30,
+    damping: 80,
   });
 
   const showSentIndicator = () => {

--- a/src/screens/chat-screen/components/message-components/EmailMessageCell.tsx
+++ b/src/screens/chat-screen/components/message-components/EmailMessageCell.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import Animated, { FadeIn } from 'react-native-reanimated';
+import Animated from 'react-native-reanimated';
+import { slowFadeIn } from '@infrastructure/animation';
 import { Channel, Message } from '@domain/types';
 import { ActivityTextCell } from './ActivityTextCell';
 import { BotTextCell } from './BotTextCell';
@@ -59,7 +60,7 @@ export const EmailMessageCell = (props: EmailMessageCellProps) => {
 
   return (
     <Animated.View
-      entering={FadeIn.duration(350)}
+      entering={slowFadeIn()}
       style={[
         tailwind.style(
           'my-[1px] w-full',

--- a/src/screens/chat-screen/components/message-components/FileCell.tsx
+++ b/src/screens/chat-screen/components/message-components/FileCell.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { Alert, Pressable, StyleSheet } from 'react-native';
 import FileViewer from 'react-native-file-viewer';
-import Animated, { Easing, FadeIn } from 'react-native-reanimated';
+import Animated from 'react-native-reanimated';
+import { contentFadeIn } from '@infrastructure/animation';
 import ReactNativeBlobUtil from 'react-native-blob-util';
 
 import { FileIcon } from '@/svg-icons';
@@ -150,7 +151,7 @@ export const FileCell = (props: FileCellProps) => {
 
   return (
     <Animated.View
-      entering={FadeIn.duration(300).easing(Easing.ease)}
+      entering={contentFadeIn()}
       style={tailwind.style(
         'w-full my-[1px]',
         isIncoming && 'items-start',

--- a/src/screens/chat-screen/components/message-components/ImageCell.tsx
+++ b/src/screens/chat-screen/components/message-components/ImageCell.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback } from 'react';
 import { Text } from 'react-native';
-import Animated, { Easing, FadeIn } from 'react-native-reanimated';
+import Animated from 'react-native-reanimated';
+import { contentFadeIn } from '@infrastructure/animation';
 import { Image, ImageBackground } from 'expo-image';
 import { CircleOff } from 'lucide-react-native';
 import { tailwind } from '@infrastructure/theme';
@@ -52,7 +53,7 @@ export const ImageCell = (props: ImageCellProps) => {
 
   return (
     <Animated.View
-      entering={FadeIn.duration(300).easing(Easing.ease)}
+      entering={contentFadeIn()}
       style={tailwind.style(
         'w-full my-[1px]',
         isIncoming && 'items-start',
@@ -118,7 +119,7 @@ export const ImageCell = (props: ImageCellProps) => {
                   />
                   <Animated.View pointerEvents={'none'}>
                     <ImageBackground
-                      source={require('../../../../assets/local/ImageCellTimeStampOverlay.png')} // eslint-disable-line @typescript-eslint/no-require-imports
+                      source={require('../../../../assets/local/ImageCellTimeStampOverlay.png')}
                       style={tailwind.style(
                         'absolute bottom-0 right-0 h-15 w-33 z-10',
                         shouldRenderAvatar

--- a/src/screens/chat-screen/components/message-components/LocationCell.tsx
+++ b/src/screens/chat-screen/components/message-components/LocationCell.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Text } from 'react-native';
-import Animated, { Easing, FadeIn } from 'react-native-reanimated';
+import Animated from 'react-native-reanimated';
+import { contentFadeIn } from '@infrastructure/animation';
 
 import { tailwind } from '@infrastructure/theme';
 import { Channel, Message, MessageStatus, UnixTimestamp } from '@domain/types';
@@ -50,7 +51,7 @@ export const LocationCell: React.FC<LocationCellProps> = props => {
 
   return (
     <Animated.View
-      entering={FadeIn.duration(300).easing(Easing.ease)}
+      entering={contentFadeIn()}
       style={tailwind.style(
         'w-full my-[1px]',
         isIncoming && 'items-start',

--- a/src/screens/chat-screen/components/message-components/TextMessageCell.tsx
+++ b/src/screens/chat-screen/components/message-components/TextMessageCell.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import Animated, { FadeIn } from 'react-native-reanimated';
+import Animated from 'react-native-reanimated';
+import { slowFadeIn } from '@infrastructure/animation';
 import { tailwind } from '@infrastructure/theme';
 
 import { Channel, Message } from '@domain/types';
@@ -45,7 +46,7 @@ export const TextMessageCell = (props: TextMessageCellProps) => {
 
   return (
     <Animated.View
-      entering={FadeIn.duration(350)}
+      entering={slowFadeIn()}
       style={[
         tailwind.style(
           'my-[1px]',

--- a/src/screens/chat-screen/components/message-components/VideoBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/VideoBubble.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Platform, Pressable } from 'react-native';
-import Animated, { Easing, FadeIn, FadeOut } from 'react-native-reanimated';
+import Animated from 'react-native-reanimated';
+import { contentFadeIn, contentFadeOut } from '@infrastructure/animation';
 import { useVideoPlayer, VideoView } from 'expo-video';
 import { useEvent } from 'expo';
 import { Image } from 'expo-image';
@@ -84,14 +85,14 @@ export const VideoBubblePlayer = (props: VideoPlayerProps) => {
       ) : null}
       {!playVideo && playerEnabled ? (
         <Animated.View
-          entering={FadeIn.duration(300).easing(Easing.ease)}
-          exiting={FadeOut.duration(300).easing(Easing.ease)}
+          entering={contentFadeIn()}
+          exiting={contentFadeOut()}
           style={tailwind.style('absolute inset-0 flex items-center justify-center')}>
           <Pressable
             onPress={handlePlayPress}
             style={tailwind.style('h-full w-full flex items-center justify-center')}>
             <Image
-              source={require('../../../../assets/local/PlayIcon.png')} // eslint-disable-line @typescript-eslint/no-require-imports
+              source={require('../../../../assets/local/PlayIcon.png')}
               style={tailwind.style('h-12 w-12 z-10')}
             />
           </Pressable>

--- a/src/screens/chat-screen/components/message-components/VideoBubble.tsx
+++ b/src/screens/chat-screen/components/message-components/VideoBubble.tsx
@@ -112,41 +112,6 @@ export const VideoBubble = (props: VideoBubbleProps) => {
           videoSrc,
         }}
       />
-      {/* TODO: Fix this */}
-      {/* <Animated.View
-        pointerEvents={'none'}
-        entering={FadeIn.duration(300).easing(Easing.ease)}
-        exiting={FadeOut.duration(300).easing(Easing.ease)}>
-        <ImageBackground
-          source={require('../../../../assets/local/ImageCellTimeStampOverlay.png')}
-          style={tailwind.style(
-            'absolute bottom-0 right-0 h-15 w-33 z-20 ',
-            shouldRenderAvatar
-              ? isOutgoing
-                ? 'rounded-br-none'
-                : isIncoming
-                  ? 'rounded-bl-none'
-                  : ''
-              : '',
-          )}>
-          <Animated.View style={tailwind.style('flex flex-row absolute right-3 bottom-[5px]')}>
-            <Text
-              style={tailwind.style(
-                'text-xs font-inter-420-20 tracking-[0.32px] leading-[14px] text-whiteA-A12 pr-1',
-              )}>
-              {messageTimestamp(timeStamp)}
-            </Text>
-            <DeliveryStatus
-              isPrivate={isPrivate}
-              status={status}
-              messageType={messageType}
-              channel={channel}
-              errorMessage={errorMessage || ''}
-              sourceId={sourceId}
-            />
-          </Animated.View>
-        </ImageBackground>
-      </Animated.View> */}
     </React.Fragment>
   );
 };

--- a/src/screens/chat-screen/components/message-components/VideoCell.tsx
+++ b/src/screens/chat-screen/components/message-components/VideoCell.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Platform, Pressable, Text } from 'react-native';
-import Animated, { Easing, FadeIn, FadeOut } from 'react-native-reanimated';
+import Animated from 'react-native-reanimated';
+import { contentFadeIn, contentFadeOut } from '@infrastructure/animation';
 import { useVideoPlayer, VideoView } from 'expo-video';
 import { useEvent } from 'expo';
 import { Image, ImageBackground } from 'expo-image';
@@ -101,14 +102,14 @@ export const VideoPlayer = (props: VideoPlayerProps) => {
       ) : null}
       {!playVideo && playerEnabled ? (
         <Animated.View
-          entering={FadeIn.duration(300).easing(Easing.ease)}
-          exiting={FadeOut.duration(300).easing(Easing.ease)}
+          entering={contentFadeIn()}
+          exiting={contentFadeOut()}
           style={tailwind.style('absolute inset-0 flex items-center justify-center')}>
           <Pressable
             onPress={handlePlayPress}
             style={tailwind.style('h-full w-full flex items-center justify-center')}>
             <Image
-              source={require('../../../../assets/local/PlayIcon.png')} // eslint-disable-line @typescript-eslint/no-require-imports
+              source={require('../../../../assets/local/PlayIcon.png')}
               style={tailwind.style('h-12 w-12 z-10')}
             />
           </Pressable>
@@ -138,7 +139,7 @@ export const VideoCell = (props: VideoCellProps) => {
 
   return (
     <Animated.View
-      entering={FadeIn.duration(300).easing(Easing.ease)}
+      entering={contentFadeIn()}
       style={tailwind.style(
         'w-full my-[1px]',
         isIncoming && 'items-start',
@@ -172,10 +173,10 @@ export const VideoCell = (props: VideoCellProps) => {
             />
             <Animated.View
               pointerEvents={'none'}
-              entering={FadeIn.duration(300).easing(Easing.ease)}
-              exiting={FadeOut.duration(300).easing(Easing.ease)}>
+              entering={contentFadeIn()}
+              exiting={contentFadeOut()}>
               <ImageBackground
-                source={require('../../../../assets/local/ImageCellTimeStampOverlay.png')} // eslint-disable-line @typescript-eslint/no-require-imports
+                source={require('../../../../assets/local/ImageCellTimeStampOverlay.png')}
                 style={tailwind.style(
                   'absolute bottom-0 right-0 h-15 w-33 z-20 ',
                   shouldRenderAvatar

--- a/src/screens/chat-screen/components/message-item/Message.tsx
+++ b/src/screens/chat-screen/components/message-item/Message.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Trash } from '@/svg-icons/common/Trash';
 import { Channel, Message } from '@domain/types';
 import Animated, { FadeIn } from 'react-native-reanimated';
-import { useAppDispatch, useAppSelector } from '@/hooks';
+import { useAppDispatch, useAppSelector, useThemedStyles } from '@/hooks';
 import { selectConversationById } from '@application/store/conversation/conversationSelectors';
 import { useChatWindowContext } from '@infrastructure/context';
 import { conversationActions } from '@application/store/conversation/conversationActions';
@@ -35,7 +35,6 @@ import i18n from '@infrastructure/i18n';
 import * as Clipboard from 'expo-clipboard';
 import { CopyIcon } from '@/svg-icons';
 import { MenuOption, MessageMenu } from '../message-menu';
-import { useThemedStyles } from '@/hooks';
 import { useThemeColors } from '@infrastructure/theme';
 import { Dimensions, View } from 'react-native';
 import { Avatar } from '@infrastructure/ui';
@@ -171,7 +170,7 @@ const MessageWrapper = ({
                 'pt-[5px] pb-0.5 flex flex-row items-center',
                 orientation === ORIENTATION.LEFT ? 'justify-start' : 'justify-end',
               )}>
-              {!shouldGroupWithPrevious && (
+              {!shouldGroupWithNext && (
                 <Animated.Text
                   style={themedTailwind.style(
                     'text-xs font-inter-420-20 tracking-[0.32px] pr-1',

--- a/src/screens/chat-screen/components/message-item/Message.tsx
+++ b/src/screens/chat-screen/components/message-item/Message.tsx
@@ -129,19 +129,19 @@ const MessageWrapper = ({
 
   return (
     <Animated.View
-      entering={FadeIn.duration(350)}
+      entering={FadeIn.duration(150)}
       style={[
         themedTailwind.style(
           'my-[1px]',
           flexOrientationClass(),
-          shouldGroupWithPrevious && orientation === ORIENTATION.LEFT ? 'ml-7' : '',
-          shouldGroupWithPrevious && orientation === ORIENTATION.RIGHT ? 'pr-7' : '',
+          shouldGroupWithNext && orientation === ORIENTATION.LEFT ? 'ml-7' : '',
+          shouldGroupWithNext && orientation === ORIENTATION.RIGHT ? 'pr-7' : '',
           !shouldGroupWithPrevious && !shouldGroupWithNext ? 'mb-2' : 'mb-1',
           item.private ? 'my-1' : '',
         ),
       ]}>
       <Animated.View style={themedTailwind.style('flex flex-row')}>
-        {!shouldGroupWithPrevious && shouldShowAvatar && orientation === ORIENTATION.LEFT ? (
+        {!shouldGroupWithNext && shouldShowAvatar && orientation === ORIENTATION.LEFT ? (
           <Animated.View style={themedTailwind.style('flex items-end justify-end mr-1')}>
             <Avatar size={'md'} src={avatarInfo.src} name={avatarInfo.name || ''} />
           </Animated.View>
@@ -192,7 +192,7 @@ const MessageWrapper = ({
             </Animated.View>
           </Animated.View>
         </MessageMenu>
-        {!shouldGroupWithPrevious && shouldShowAvatar && orientation === ORIENTATION.RIGHT ? (
+        {!shouldGroupWithNext && shouldShowAvatar && orientation === ORIENTATION.RIGHT ? (
           <Animated.View style={themedTailwind.style('flex items-end justify-end ml-1')}>
             <Avatar size={'md'} src={avatarInfo.src} name={avatarInfo.name || ''} />
           </Animated.View>

--- a/src/screens/chat-screen/components/message-item/Message.tsx
+++ b/src/screens/chat-screen/components/message-item/Message.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { Trash } from '@/svg-icons/common/Trash';
 import { Channel, Message } from '@domain/types';
-import Animated, { FadeIn } from 'react-native-reanimated';
+import Animated from 'react-native-reanimated';
+import { quickFadeIn } from '@infrastructure/animation';
 import { useAppDispatch, useAppSelector, useThemedStyles } from '@/hooks';
 import { selectConversationById } from '@application/store/conversation/conversationSelectors';
 import { useChatWindowContext } from '@infrastructure/context';
@@ -129,7 +130,7 @@ const MessageWrapper = ({
 
   return (
     <Animated.View
-      entering={FadeIn.duration(150)}
+      entering={quickFadeIn()}
       style={[
         themedTailwind.style(
           'my-[1px]',

--- a/src/screens/chat-screen/components/message-list/MessagesList.tsx
+++ b/src/screens/chat-screen/components/message-list/MessagesList.tsx
@@ -1,8 +1,7 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React from 'react';
 
 import Animated, { LinearTransition } from 'react-native-reanimated';
 import { FlashList, type FlashListRef } from '@shopify/flash-list';
-import { ActivityIndicator, View } from 'react-native';
 
 import { tailwind } from '@infrastructure/theme';
 import { useThemedStyles } from '@infrastructure/hooks';
@@ -15,6 +14,8 @@ export type FlashListRenderProps = {
   item: { date: string } | Message;
   index: number;
 };
+
+const AnimatedFlashlist = Animated.createAnimatedComponent(FlashList<Message | { date: string }>);
 
 type DateSectionProps = { item: { date: string } };
 
@@ -43,10 +44,6 @@ type MessagesListPresentationProps = {
   currentUserId: number;
 };
 
-// Timeout (ms) to force reveal the list if onScroll never fires
-// (e.g., too few messages to require scrolling)
-const LAYOUT_READY_FALLBACK_MS = 500;
-
 export const MessagesList = ({
   messages,
   isFlashListReady,
@@ -55,40 +52,10 @@ export const MessagesList = ({
   isEmailInbox,
   currentUserId,
 }: MessagesListPresentationProps) => {
-  const themedTailwind = useThemedStyles();
   const { messageListRef } = useRefsContext();
   const typedMessageListRef = messageListRef as React.RefObject<FlashListRef<
     Message | { date: string }
   > | null>;
-
-  // Track whether the FlashList has completed its initial layout + scroll-to-bottom
-  // so we can hide the progressive top-down fill that startRenderingFromBottom causes.
-  const [isLayoutReady, setIsLayoutReady] = useState(false);
-  const layoutReadyTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  // Reveal the list — called when we're confident the list is positioned at the bottom.
-  const revealList = useCallback(() => {
-    if (layoutReadyTimeout.current) {
-      clearTimeout(layoutReadyTimeout.current);
-      layoutReadyTimeout.current = null;
-    }
-    setIsLayoutReady(true);
-  }, []);
-
-  // Fallback timer: if no scroll event fires within LAYOUT_READY_FALLBACK_MS
-  // (e.g., very few messages that don't fill the viewport), reveal anyway.
-  useEffect(() => {
-    if (!isLayoutReady) {
-      layoutReadyTimeout.current = setTimeout(revealList, LAYOUT_READY_FALLBACK_MS);
-    }
-    return () => {
-      if (layoutReadyTimeout.current) {
-        clearTimeout(layoutReadyTimeout.current);
-      }
-    };
-    // Only run once on mount
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const handleRender = ({ item, index }: { item: Message | { date: string }; index: number }) => {
     if ('date' in item) {
@@ -111,65 +78,33 @@ export const MessagesList = ({
     <Animated.View
       layout={LinearTransition.springify().damping(38).stiffness(240)}
       style={tailwind.style('flex-1 min-h-10')}>
-      {/* Loading indicator shown while FlashList is hidden during initial layout */}
-      {!isLayoutReady && (
-        <View
-          style={themedTailwind.style(
-            'absolute inset-0 z-10 items-center justify-center bg-solid-1',
-          )}>
-          <ActivityIndicator />
-        </View>
-      )}
-      {/* Hide the FlashList with opacity:0 during initial layout to prevent
-          the visible top-down progressive fill. The list stays mounted so it
-          can measure and lay out items + scroll to bottom. */}
-      <View style={{ flex: 1, opacity: isLayoutReady ? 1 : 0 }}>
-        <FlashList
-          ref={typedMessageListRef}
-          overrideProps={{ initialDrawBatchSize: 10 }}
-          drawDistance={500}
-          getItemType={item => {
-            if ('date' in item) return 'date';
-            return 'message';
-          }}
-          onScroll={() => {
-            if (!isFlashListReady) {
-              setFlashListReady(true);
-            }
-            // The first onScroll event means startRenderingFromBottom has
-            // completed its initial scroll positioning — safe to reveal.
-            if (!isLayoutReady) {
-              revealList();
-            }
-          }}
-          onLoad={() => {
-            // onLoad fires when FlashList completes its initial render.
-            // If there aren't enough messages to scroll, onScroll won't fire,
-            // so this serves as an additional trigger to reveal the list.
-            if (!isLayoutReady) {
-              revealList();
-            }
-          }}
-          maintainVisibleContentPosition={{
-            startRenderingFromBottom: true,
-            autoscrollToBottomThreshold: 0.5,
-            animateAutoScrollToBottom: true,
-          }}
-          showsVerticalScrollIndicator={false}
-          renderItem={handleRender}
-          onStartReached={onStartReached}
-          onStartReachedThreshold={0.2}
-          data={messages}
-          contentContainerStyle={tailwind.style('px-3')}
-          keyboardShouldPersistTaps="handled"
-          keyExtractor={(item: { date: string } | Message) => {
-            if ('date' in item) {
-              return item.date.toString();
-            }
-            return item.id.toString();
-          }}
-        />
-      </View>
+      <AnimatedFlashlist
+        layout={LinearTransition.springify().damping(38).stiffness(240)}
+        onScroll={() => {
+          if (!isFlashListReady) {
+            setFlashListReady(true);
+          }
+        }}
+        ref={typedMessageListRef}
+        maintainVisibleContentPosition={{
+          startRenderingFromBottom: true,
+          autoscrollToBottomThreshold: 0.5,
+          animateAutoScrollToBottom: true,
+        }}
+        showsVerticalScrollIndicator={false}
+        renderItem={handleRender}
+        onStartReached={onStartReached}
+        onStartReachedThreshold={0.2}
+        data={messages}
+        contentContainerStyle={tailwind.style('px-3')}
+        keyboardShouldPersistTaps="handled"
+        keyExtractor={(item: { date: string } | Message) => {
+          if ('date' in item) {
+            return item.date.toString();
+          }
+          return item.id.toString();
+        }}
+      />
     </Animated.View>
   );
 };

--- a/src/screens/chat-screen/components/message-list/MessagesList.tsx
+++ b/src/screens/chat-screen/components/message-list/MessagesList.tsx
@@ -1,13 +1,8 @@
 import React from 'react';
 
-import Animated, {
-  interpolate,
-  LinearTransition,
-  useAnimatedStyle,
-  withSpring,
-} from 'react-native-reanimated';
+import Animated, { LinearTransition } from 'react-native-reanimated';
 import { FlashList, type FlashListRef } from '@shopify/flash-list';
-import { useAppKeyboardAnimation } from '@infrastructure/utils';
+
 import { tailwind } from '@infrastructure/theme';
 import { useThemedStyles } from '@infrastructure/hooks';
 import { Message } from '@domain/types';
@@ -57,7 +52,6 @@ export const MessagesList = ({
   isEmailInbox,
   currentUserId,
 }: MessagesListPresentationProps) => {
-  const { progress, height } = useAppKeyboardAnimation();
   const { messageListRef } = useRefsContext();
   const typedMessageListRef = messageListRef as React.RefObject<FlashListRef<
     Message | { date: string }
@@ -80,19 +74,10 @@ export const MessagesList = ({
     // return <MessageItemContainer item={item} index={index} />;
   };
 
-  const animatedFlashlistStyle = useAnimatedStyle(() => {
-    return {
-      marginBottom: withSpring(interpolate(progress.value, [0, 1], [0, height.value]), {
-        stiffness: 240,
-        damping: 38,
-      }),
-    };
-  });
-
   return (
     <Animated.View
       layout={LinearTransition.springify().damping(38).stiffness(240)}
-      style={[tailwind.style('flex-1 min-h-10'), animatedFlashlistStyle]}>
+      style={tailwind.style('flex-1 min-h-10')}>
       <AnimatedFlashlist
         layout={LinearTransition.springify().damping(38).stiffness(240)}
         onScroll={() => {
@@ -103,7 +88,7 @@ export const MessagesList = ({
         ref={typedMessageListRef}
         maintainVisibleContentPosition={{
           startRenderingFromBottom: true,
-          autoscrollToBottomThreshold: 0.1,
+          autoscrollToBottomThreshold: 0.5,
           animateAutoScrollToBottom: true,
         }}
         showsVerticalScrollIndicator={false}

--- a/src/screens/chat-screen/components/message-list/MessagesList.tsx
+++ b/src/screens/chat-screen/components/message-list/MessagesList.tsx
@@ -15,8 +15,6 @@ export type FlashListRenderProps = {
   index: number;
 };
 
-const AnimatedFlashlist = Animated.createAnimatedComponent(FlashList<Message | { date: string }>);
-
 type DateSectionProps = { item: { date: string } };
 
 const DateSection = ({ item }: DateSectionProps) => {
@@ -78,14 +76,19 @@ export const MessagesList = ({
     <Animated.View
       layout={LinearTransition.springify().damping(38).stiffness(240)}
       style={tailwind.style('flex-1 min-h-10')}>
-      <AnimatedFlashlist
-        layout={LinearTransition.springify().damping(38).stiffness(240)}
+      <FlashList
+        ref={typedMessageListRef}
+        overrideProps={{ initialDrawBatchSize: 10 }}
+        drawDistance={500}
+        getItemType={item => {
+          if ('date' in item) return 'date';
+          return 'message';
+        }}
         onScroll={() => {
           if (!isFlashListReady) {
             setFlashListReady(true);
           }
         }}
-        ref={typedMessageListRef}
         maintainVisibleContentPosition={{
           startRenderingFromBottom: true,
           autoscrollToBottomThreshold: 0.5,

--- a/src/screens/chat-screen/components/message-list/MessagesList.tsx
+++ b/src/screens/chat-screen/components/message-list/MessagesList.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import Animated, { LinearTransition } from 'react-native-reanimated';
 import { FlashList, type FlashListRef } from '@shopify/flash-list';
+import { ActivityIndicator, View } from 'react-native';
 
 import { tailwind } from '@infrastructure/theme';
 import { useThemedStyles } from '@infrastructure/hooks';
@@ -42,6 +43,10 @@ type MessagesListPresentationProps = {
   currentUserId: number;
 };
 
+// Timeout (ms) to force reveal the list if onScroll never fires
+// (e.g., too few messages to require scrolling)
+const LAYOUT_READY_FALLBACK_MS = 500;
+
 export const MessagesList = ({
   messages,
   isFlashListReady,
@@ -50,10 +55,40 @@ export const MessagesList = ({
   isEmailInbox,
   currentUserId,
 }: MessagesListPresentationProps) => {
+  const themedTailwind = useThemedStyles();
   const { messageListRef } = useRefsContext();
   const typedMessageListRef = messageListRef as React.RefObject<FlashListRef<
     Message | { date: string }
   > | null>;
+
+  // Track whether the FlashList has completed its initial layout + scroll-to-bottom
+  // so we can hide the progressive top-down fill that startRenderingFromBottom causes.
+  const [isLayoutReady, setIsLayoutReady] = useState(false);
+  const layoutReadyTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Reveal the list — called when we're confident the list is positioned at the bottom.
+  const revealList = useCallback(() => {
+    if (layoutReadyTimeout.current) {
+      clearTimeout(layoutReadyTimeout.current);
+      layoutReadyTimeout.current = null;
+    }
+    setIsLayoutReady(true);
+  }, []);
+
+  // Fallback timer: if no scroll event fires within LAYOUT_READY_FALLBACK_MS
+  // (e.g., very few messages that don't fill the viewport), reveal anyway.
+  useEffect(() => {
+    if (!isLayoutReady) {
+      layoutReadyTimeout.current = setTimeout(revealList, LAYOUT_READY_FALLBACK_MS);
+    }
+    return () => {
+      if (layoutReadyTimeout.current) {
+        clearTimeout(layoutReadyTimeout.current);
+      }
+    };
+    // Only run once on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleRender = ({ item, index }: { item: Message | { date: string }; index: number }) => {
     if ('date' in item) {
@@ -76,38 +111,65 @@ export const MessagesList = ({
     <Animated.View
       layout={LinearTransition.springify().damping(38).stiffness(240)}
       style={tailwind.style('flex-1 min-h-10')}>
-      <FlashList
-        ref={typedMessageListRef}
-        overrideProps={{ initialDrawBatchSize: 10 }}
-        drawDistance={500}
-        getItemType={item => {
-          if ('date' in item) return 'date';
-          return 'message';
-        }}
-        onScroll={() => {
-          if (!isFlashListReady) {
-            setFlashListReady(true);
-          }
-        }}
-        maintainVisibleContentPosition={{
-          startRenderingFromBottom: true,
-          autoscrollToBottomThreshold: 0.5,
-          animateAutoScrollToBottom: true,
-        }}
-        showsVerticalScrollIndicator={false}
-        renderItem={handleRender}
-        onStartReached={onStartReached}
-        onStartReachedThreshold={0.2}
-        data={messages}
-        contentContainerStyle={tailwind.style('px-3')}
-        keyboardShouldPersistTaps="handled"
-        keyExtractor={(item: { date: string } | Message) => {
-          if ('date' in item) {
-            return item.date.toString();
-          }
-          return item.id.toString();
-        }}
-      />
+      {/* Loading indicator shown while FlashList is hidden during initial layout */}
+      {!isLayoutReady && (
+        <View
+          style={themedTailwind.style(
+            'absolute inset-0 z-10 items-center justify-center bg-solid-1',
+          )}>
+          <ActivityIndicator />
+        </View>
+      )}
+      {/* Hide the FlashList with opacity:0 during initial layout to prevent
+          the visible top-down progressive fill. The list stays mounted so it
+          can measure and lay out items + scroll to bottom. */}
+      <View style={{ flex: 1, opacity: isLayoutReady ? 1 : 0 }}>
+        <FlashList
+          ref={typedMessageListRef}
+          overrideProps={{ initialDrawBatchSize: 10 }}
+          drawDistance={500}
+          getItemType={item => {
+            if ('date' in item) return 'date';
+            return 'message';
+          }}
+          onScroll={() => {
+            if (!isFlashListReady) {
+              setFlashListReady(true);
+            }
+            // The first onScroll event means startRenderingFromBottom has
+            // completed its initial scroll positioning — safe to reveal.
+            if (!isLayoutReady) {
+              revealList();
+            }
+          }}
+          onLoad={() => {
+            // onLoad fires when FlashList completes its initial render.
+            // If there aren't enough messages to scroll, onScroll won't fire,
+            // so this serves as an additional trigger to reveal the list.
+            if (!isLayoutReady) {
+              revealList();
+            }
+          }}
+          maintainVisibleContentPosition={{
+            startRenderingFromBottom: true,
+            autoscrollToBottomThreshold: 0.5,
+            animateAutoScrollToBottom: true,
+          }}
+          showsVerticalScrollIndicator={false}
+          renderItem={handleRender}
+          onStartReached={onStartReached}
+          onStartReachedThreshold={0.2}
+          data={messages}
+          contentContainerStyle={tailwind.style('px-3')}
+          keyboardShouldPersistTaps="handled"
+          keyExtractor={(item: { date: string } | Message) => {
+            if ('date' in item) {
+              return item.date.toString();
+            }
+            return item.id.toString();
+          }}
+        />
+      </View>
     </Animated.View>
   );
 };

--- a/src/screens/chat-screen/components/message-list/MessagesList.tsx
+++ b/src/screens/chat-screen/components/message-list/MessagesList.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import Animated, { LinearTransition } from 'react-native-reanimated';
+import { View } from 'react-native';
+import Animated from 'react-native-reanimated';
 import { FlashList, type FlashListRef } from '@shopify/flash-list';
 
 import { tailwind } from '@infrastructure/theme';
@@ -14,8 +15,6 @@ export type FlashListRenderProps = {
   item: { date: string } | Message;
   index: number;
 };
-
-const AnimatedFlashlist = Animated.createAnimatedComponent(FlashList<Message | { date: string }>);
 
 type DateSectionProps = { item: { date: string } };
 
@@ -39,7 +38,7 @@ type MessagesListPresentationProps = {
   messages: (Message | { date: string })[];
   isFlashListReady: boolean;
   setFlashListReady: (ready: boolean) => void;
-  onStartReached: () => void;
+  onEndReached: () => void;
   isEmailInbox: boolean;
   currentUserId: number;
 };
@@ -48,7 +47,7 @@ export const MessagesList = ({
   messages,
   isFlashListReady,
   setFlashListReady,
-  onStartReached,
+  onEndReached,
   isEmailInbox,
   currentUserId,
 }: MessagesListPresentationProps) => {
@@ -75,27 +74,21 @@ export const MessagesList = ({
   };
 
   return (
-    <Animated.View
-      layout={LinearTransition.springify().damping(38).stiffness(240)}
-      style={tailwind.style('flex-1 min-h-10')}>
-      <AnimatedFlashlist
-        layout={LinearTransition.springify().damping(38).stiffness(240)}
+    <View style={tailwind.style('flex-1 min-h-10')}>
+      <FlashList
+        ref={typedMessageListRef}
+        inverted
+        data={messages}
+        renderItem={handleRender}
+        estimatedItemSize={80}
         onScroll={() => {
           if (!isFlashListReady) {
             setFlashListReady(true);
           }
         }}
-        ref={typedMessageListRef}
-        maintainVisibleContentPosition={{
-          startRenderingFromBottom: true,
-          autoscrollToBottomThreshold: 0.5,
-          animateAutoScrollToBottom: true,
-        }}
+        onEndReached={onEndReached}
+        onEndReachedThreshold={0.2}
         showsVerticalScrollIndicator={false}
-        renderItem={handleRender}
-        onStartReached={onStartReached}
-        onStartReachedThreshold={0.2}
-        data={messages}
         contentContainerStyle={tailwind.style('px-3')}
         keyboardShouldPersistTaps="handled"
         keyExtractor={(item: { date: string } | Message) => {
@@ -105,6 +98,6 @@ export const MessagesList = ({
           return item.id.toString();
         }}
       />
-    </Animated.View>
+    </View>
   );
 };

--- a/src/screens/chat-screen/components/message-list/MessagesListContainer.tsx
+++ b/src/screens/chat-screen/components/message-list/MessagesListContainer.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useAppSelector, useAppDispatch, useThemedStyles } from '@/hooks';
 import { useChatWindowContext } from '@infrastructure/context';
-import { AppState, Platform } from 'react-native';
+import { AppState, Platform, Animated } from 'react-native';
 import { KeyboardGestureArea } from 'react-native-keyboard-controller';
 import flatMap from 'lodash/flatMap';
 import useDeepCompareEffect from 'use-deep-compare-effect';
@@ -13,7 +13,6 @@ import {
 } from '@application/store/conversation/conversationSelectors';
 import { conversationActions } from '@application/store/conversation/conversationActions';
 import { selectAttachments } from '@application/store/conversation/sendMessageSlice';
-import { Animated } from 'react-native';
 import { getGroupedMessages, isAnEmailChannel } from '@infrastructure/utils';
 import { MessagesList } from './MessagesList';
 import { conversationParticipantActions } from '@application/store/conversation-participant/conversationParticipantActions';
@@ -136,9 +135,9 @@ export const MessagesListContainer = () => {
     };
   }, [appState, conversationId, dispatch]);
 
-  // With FlashList v2 (non-inverted, chronological order), loading older messages
-  // happens when the user scrolls to the TOP (start), not end.
-  const onStartReached = () => {
+  // With inverted FlashList, scrolling UP (toward older messages) triggers onEndReached.
+  // "End" of the data array = oldest messages = visual top of the inverted list.
+  const onEndReached = () => {
     const shouldFetchMoreMessages = !isAllMessagesFetched && !isLoadingMessages && isFlashListReady;
     if (shouldFetchMoreMessages) {
       loadMessages({ loadingMessagesForFirstTime: false });
@@ -153,21 +152,25 @@ export const MessagesListContainer = () => {
 
   const groupedMessages = getGroupedMessages(messages);
 
-  // FlashList v2 removed the `inverted` prop. We now use a chronological (oldest-first)
-  // data order with `maintainVisibleContentPosition.startRenderingFromBottom` instead.
-  // The selector returns newest-first, and getGroupedMessages preserves that order,
-  // so we reverse the flat list to get chronological order for the non-inverted FlashList.
-  const allMessagesNewestFirst = flatMap(groupedMessages, section => [
+  // With inverted FlashList, data must be newest-first.
+  // Index 0 = newest message, renders at visual bottom.
+  // Date separators come AFTER each group's messages in the array,
+  // which means they render ABOVE (visually) in the inverted list.
+  const allMessages = flatMap(groupedMessages, section => [
     ...section.data,
     { date: section.date },
   ]);
-  const allMessages = [...allMessagesNewestFirst].reverse();
 
   const messagesWithGrouping = allMessages.map((message, index) => {
+    // With inverted list (newest-first data), array index+1 = older = visually ABOVE.
+    // shouldGroupWithNext(index) checks if [index] groups with [index+1] (= visual above).
+    // We SWAP the assignments so the prop names match their VISUAL meaning:
+    //   groupWithNext (visually below) = does the message below me (index-1, newer) group with me?
+    //   groupWithPrevious (visually above) = do I group with the message above me (index+1, older)?
     return {
       ...message,
-      groupWithNext: shouldGroupWithNext(index, allMessages as MessageOrDate[]),
-      groupWithPrevious: shouldGroupWithNext(index - 1, allMessages as MessageOrDate[]),
+      groupWithNext: shouldGroupWithNext(index - 1, allMessages as MessageOrDate[]),
+      groupWithPrevious: shouldGroupWithNext(index, allMessages as MessageOrDate[]),
     };
   });
 
@@ -189,7 +192,7 @@ export const MessagesListContainer = () => {
         messages={messagesWithGrouping}
         isFlashListReady={isFlashListReady}
         setFlashListReady={setFlashListReady}
-        onStartReached={onStartReached}
+        onEndReached={onEndReached}
         isEmailInbox={isEmailInbox}
         currentUserId={userId as number}
       />

--- a/src/screens/chat-screen/components/message-list/stories/Basic.stories.tsx
+++ b/src/screens/chat-screen/components/message-list/stories/Basic.stories.tsx
@@ -1,9 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { ScrollView } from 'react-native';
-import { Platform } from 'react-native';
+import { ScrollView, Platform, Animated } from 'react-native';
 import { KeyboardGestureArea, KeyboardProvider } from 'react-native-keyboard-controller';
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
-import { Animated } from 'react-native';
 import { configureStore, createSlice } from '@reduxjs/toolkit';
 import { tailwind } from '@infrastructure/theme';
 import { MessagesList } from '../MessagesList';
@@ -77,7 +75,7 @@ export const Basic: Story = {
                       messages={ALL_MESSAGES_MOCKDATA}
                       isFlashListReady={false}
                       setFlashListReady={() => {}}
-                      onStartReached={() => {}}
+                      onEndReached={() => {}}
                     />
                   </PlatformSpecificKeyboardWrapperComponent>
                 </ScrollView>

--- a/src/screens/chat-screen/components/message-list/stories/EmailMessageList.stories.tsx
+++ b/src/screens/chat-screen/components/message-list/stories/EmailMessageList.stories.tsx
@@ -1,9 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { ScrollView } from 'react-native';
-import { Platform } from 'react-native';
+import { ScrollView, Platform, Animated } from 'react-native';
 import { KeyboardGestureArea, KeyboardProvider } from 'react-native-keyboard-controller';
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
-import { Animated } from 'react-native';
 import { configureStore, createSlice } from '@reduxjs/toolkit';
 import { tailwind } from '@infrastructure/theme';
 import { MessagesList } from '../MessagesList';
@@ -75,7 +73,7 @@ export const EmailMessageList: Story = {
                       messages={ALL_MESSAGES_MOCKDATA}
                       isFlashListReady={false}
                       setFlashListReady={() => {}}
-                      onStartReached={() => {}}
+                      onEndReached={() => {}}
                       isEmailInbox={true}
                       currentUserId={1}
                     />

--- a/src/screens/chat-screen/components/message-list/stories/Instagram.stories.tsx
+++ b/src/screens/chat-screen/components/message-list/stories/Instagram.stories.tsx
@@ -1,9 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { ScrollView } from 'react-native';
-import { Platform } from 'react-native';
+import { ScrollView, Platform, Animated } from 'react-native';
 import { KeyboardGestureArea, KeyboardProvider } from 'react-native-keyboard-controller';
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
-import { Animated } from 'react-native';
 import { configureStore, createSlice } from '@reduxjs/toolkit';
 import { tailwind } from '@infrastructure/theme';
 import { MessagesList } from '../MessagesList';
@@ -75,7 +73,7 @@ export const Instagram: Story = {
                       messages={ALL_MESSAGES_MOCKDATA}
                       isFlashListReady={false}
                       setFlashListReady={() => {}}
-                      onStartReached={() => {}}
+                      onEndReached={() => {}}
                       isEmailInbox={false}
                       currentUserId={1}
                     />

--- a/src/screens/chat-screen/components/message-list/stories/mock-data/helper.ts
+++ b/src/screens/chat-screen/components/message-list/stories/mock-data/helper.ts
@@ -5,6 +5,7 @@ import flatMap from 'lodash/flatMap';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const getAllGroupedMessages = (messages: any[]) => {
+  // Mock data comes in chronological order; reverse to newest-first for inverted FlashList
   const MESSAGES_LIST_MOCKDATA = [...messages].reverse();
 
   const updatedMessages = MESSAGES_LIST_MOCKDATA.map(
@@ -13,6 +14,8 @@ export const getAllGroupedMessages = (messages: any[]) => {
 
   const groupedMessages = getGroupedMessages(updatedMessages);
 
+  // With inverted FlashList, data is newest-first.
+  // Date separators come AFTER each group's messages in the array.
   const allMessages = flatMap(groupedMessages, section => [
     ...section.data,
     { date: section.date },

--- a/src/screens/chat-screen/components/message-menu/MessageMenu.tsx
+++ b/src/screens/chat-screen/components/message-menu/MessageMenu.tsx
@@ -3,11 +3,8 @@ import { Platform, Pressable, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, { interpolate, runOnJS, useAnimatedStyle } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import {
-  BottomSheetBackdropProps,
-  BottomSheetModal,
-  useBottomSheetSpringConfigs,
-} from '@gorhom/bottom-sheet';
+import { BottomSheetBackdropProps, BottomSheetModal } from '@gorhom/bottom-sheet';
+import { spring } from '@infrastructure/animation';
 import * as ContextMenu from 'zeego/context-menu';
 
 import { tailwind } from '@infrastructure/theme';
@@ -82,12 +79,6 @@ export const MessageMenu = (props: PropsWithChildren<MessageMenuProps>) => {
 
   const { bottom } = useSafeAreaInsets();
 
-  const animationConfigs = useBottomSheetSpringConfigs({
-    mass: 1,
-    stiffness: 420,
-    damping: 80,
-  });
-
   const handleOnDismiss = () => {
     contextMenuSheetRef.current?.dismiss();
   };
@@ -121,7 +112,7 @@ export const MessageMenu = (props: PropsWithChildren<MessageMenuProps>) => {
           style={tailwind.style('mx-3 rounded-[26px] overflow-hidden')}
           detached
           bottomInset={bottom === 0 ? 12 : bottom}
-          animationConfigs={animationConfigs}
+          animationConfigs={spring.sheet}
           enablePanDownToClose
           snapPoints={[menuOptions.length * 44 + 4 + 37]}
           onDismiss={handleOnDismiss}>

--- a/src/screens/chat-screen/components/message-menu/MessageMenu.tsx
+++ b/src/screens/chat-screen/components/message-menu/MessageMenu.tsx
@@ -85,7 +85,7 @@ export const MessageMenu = (props: PropsWithChildren<MessageMenuProps>) => {
   const animationConfigs = useBottomSheetSpringConfigs({
     mass: 1,
     stiffness: 420,
-    damping: 30,
+    damping: 80,
   });
 
   const handleOnDismiss = () => {

--- a/src/screens/chat-screen/components/reply-box/MessageTextInput.tsx
+++ b/src/screens/chat-screen/components/reply-box/MessageTextInput.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useEffect, useMemo, type ReactNode } from 'react';
 import { Platform, StyleSheet, ScrollView } from 'react-native';
-import Animated, { LayoutAnimationConfig, LinearTransition } from 'react-native-reanimated';
+import Animated, { LayoutAnimationConfig } from 'react-native-reanimated';
 
+import { softLayout } from '@infrastructure/animation';
 import { useChatWindowContext } from '@infrastructure/context';
 import { tailwind } from '@infrastructure/theme';
 import { useAppDispatch, useAppSelector, useThemedStyles } from '@/hooks';
@@ -166,13 +167,11 @@ export const MessageTextInput = ({
 
   return (
     <LayoutAnimationConfig skipEntering={true}>
-      <Animated.View
-        layout={LinearTransition.springify().damping(28).stiffness(200)}
-        style={[tailwind.style('flex-1 my-0.5')]}>
+      <Animated.View layout={softLayout()} style={[tailwind.style('flex-1 my-0.5')]}>
         <MentionInput
           // @ts-expect-error MentionInput ref typing issue with forwardRef
           ref={textInputRef}
-          layout={LinearTransition.springify().damping(28).stiffness(200)}
+          layout={softLayout()}
           onChange={onChangeText}
           partTypes={[
             {

--- a/src/screens/chat-screen/components/reply-box/MessageTextInput.tsx
+++ b/src/screens/chat-screen/components/reply-box/MessageTextInput.tsx
@@ -167,12 +167,12 @@ export const MessageTextInput = ({
   return (
     <LayoutAnimationConfig skipEntering={true}>
       <Animated.View
-        layout={LinearTransition.springify().damping(20).stiffness(120)}
+        layout={LinearTransition.springify().damping(28).stiffness(200)}
         style={[tailwind.style('flex-1 my-0.5')]}>
         <MentionInput
           // @ts-expect-error MentionInput ref typing issue with forwardRef
           ref={textInputRef}
-          layout={LinearTransition.springify().damping(20).stiffness(120)}
+          layout={LinearTransition.springify().damping(28).stiffness(200)}
           onChange={onChangeText}
           partTypes={[
             {

--- a/src/screens/chat-screen/components/reply-box/ReplyBoxContainer.tsx
+++ b/src/screens/chat-screen/components/reply-box/ReplyBoxContainer.tsx
@@ -74,8 +74,8 @@ import { AudioRecorder } from '../audio-recorder/AudioRecorder';
 import { VoiceRecordButton } from './buttons/VoiceRecordButton';
 
 const SHEET_APPEAR_SPRING_CONFIG = {
-  damping: 20,
-  stiffness: 120,
+  damping: 28,
+  stiffness: 200,
 };
 
 // TODO: Implement this

--- a/src/screens/chat-screen/components/reply-box/ReplyBoxContainer.tsx
+++ b/src/screens/chat-screen/components/reply-box/ReplyBoxContainer.tsx
@@ -4,7 +4,6 @@ import { KeyboardStickyView } from 'react-native-keyboard-controller';
 import Animated, {
   FadeIn,
   FadeOut,
-  LinearTransition,
   useDerivedValue,
   useAnimatedStyle,
   withSpring,
@@ -70,7 +69,7 @@ import {
 } from '@infrastructure/utils/messageVariableUtils';
 import { ReplyEmailHead } from './ReplyEmailHead';
 import { selectAssignableParticipantsByInboxId } from '@application/store/assignable-agent/assignableAgentSelectors';
-import { spring } from '@infrastructure/animation';
+import { spring, snappyLayout } from '@infrastructure/animation';
 import { AudioRecorder } from '../audio-recorder/AudioRecorder';
 import { VoiceRecordButton } from './buttons/VoiceRecordButton';
 
@@ -433,7 +432,7 @@ const BottomSheetContent = () => {
       )}
 
       <Animated.View
-        layout={LinearTransition.springify().damping(80).stiffness(240)}
+        layout={snappyLayout()}
         style={themedTailwind.style(
           `pb-2 border-t-[1px] border-t-slate-6 ${shouldShowReplyHeader ? 'pt-0' : 'pt-2'}`,
         )}>

--- a/src/screens/chat-screen/components/reply-box/ReplyBoxContainer.tsx
+++ b/src/screens/chat-screen/components/reply-box/ReplyBoxContainer.tsx
@@ -439,7 +439,7 @@ const BottomSheetContent = () => {
       )}
 
       <Animated.View
-        layout={LinearTransition.springify().damping(38).stiffness(240)}
+        layout={LinearTransition.springify().damping(80).stiffness(240)}
         style={themedTailwind.style(
           `pb-2 border-t-[1px] border-t-slate-6 ${shouldShowReplyHeader ? 'pt-0' : 'pt-2'}`,
         )}>

--- a/src/screens/chat-screen/components/reply-box/ReplyBoxContainer.tsx
+++ b/src/screens/chat-screen/components/reply-box/ReplyBoxContainer.tsx
@@ -373,7 +373,7 @@ const BottomSheetContent = () => {
     });
 
     requestAnimationFrame(() => {
-      messageListRef?.current?.scrollToEnd({ animated: true });
+      messageListRef?.current?.scrollToOffset({ offset: 0, animated: true });
     });
   };
 

--- a/src/screens/chat-screen/components/reply-box/ReplyBoxContainer.tsx
+++ b/src/screens/chat-screen/components/reply-box/ReplyBoxContainer.tsx
@@ -1,13 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Alert, Keyboard, Pressable, TextInput } from 'react-native';
 import { KeyboardStickyView } from 'react-native-keyboard-controller';
-import Animated, {
-  FadeIn,
-  FadeOut,
-  useDerivedValue,
-  useAnimatedStyle,
-  withSpring,
-} from 'react-native-reanimated';
+import Animated, { useDerivedValue, useAnimatedStyle, withSpring } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Lock, LockOpen } from 'lucide-react-native';
 
@@ -69,7 +63,7 @@ import {
 } from '@infrastructure/utils/messageVariableUtils';
 import { ReplyEmailHead } from './ReplyEmailHead';
 import { selectAssignableParticipantsByInboxId } from '@application/store/assignable-agent/assignableAgentSelectors';
-import { spring, snappyLayout } from '@infrastructure/animation';
+import { spring, snappyLayout, standardFadeIn, instantFadeOut } from '@infrastructure/animation';
 import { AudioRecorder } from '../audio-recorder/AudioRecorder';
 import { VoiceRecordButton } from './buttons/VoiceRecordButton';
 
@@ -437,7 +431,7 @@ const BottomSheetContent = () => {
           `pb-2 border-t-[1px] border-t-slate-6 ${shouldShowReplyHeader ? 'pt-0' : 'pt-2'}`,
         )}>
         {quoteMessage && (
-          <Animated.View entering={FadeIn.duration(250)} exiting={FadeOut.duration(10)}>
+          <Animated.View entering={standardFadeIn()} exiting={instantFadeOut()}>
             <QuoteReply />s
           </Animated.View>
         )}

--- a/src/screens/chat-screen/components/reply-box/ReplyBoxContainer.tsx
+++ b/src/screens/chat-screen/components/reply-box/ReplyBoxContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Alert, Keyboard, Pressable, TextInput } from 'react-native';
 import { KeyboardStickyView } from 'react-native-keyboard-controller';
 import Animated, {
@@ -24,6 +24,7 @@ import {
   isAWebWidgetInbox,
   isAPIInbox,
   isAnInstagramChannel,
+  getTypingUsersText,
 } from '@infrastructure/utils';
 import { useAppDispatch, useAppSelector, useThemedStyles } from '@/hooks';
 import { MESSAGE_MAX_LENGTH, REPLY_EDITOR_MODES } from '@domain/constants';
@@ -42,7 +43,10 @@ import {
   selectUserName,
   selectUserThumbnail,
 } from '@application/store/auth/authSelectors';
-import { selectConversationById } from '@application/store/conversation/conversationSelectors';
+import {
+  selectConversationById,
+  getLastEmailInSelectedChat,
+} from '@application/store/conversation/conversationSelectors';
 import { selectInboxById } from '@application/store/inbox/inboxSelectors';
 import { conversationActions } from '@application/store/conversation/conversationActions';
 
@@ -55,7 +59,6 @@ import { AttachedMedia } from '../message-components/AttachedMedia';
 import { CommandOptionsMenu } from '../message-components/CommandOptionsMenu';
 import { SendMessagePayload } from '@application/store/conversation/conversationTypes';
 import { TypingIndicator } from './TypingIndicator';
-import { getTypingUsersText } from '@infrastructure/utils';
 import { selectTypingUsersByConversationId } from '@application/store/conversation/conversationTypingSlice';
 import { Agent, CannedResponse, Conversation } from '@domain/types';
 import AnalyticsHelper from '@infrastructure/utils/analyticsUtils';
@@ -66,7 +69,6 @@ import {
   getAllUndefinedVariablesInMessage,
 } from '@infrastructure/utils/messageVariableUtils';
 import { ReplyEmailHead } from './ReplyEmailHead';
-import { getLastEmailInSelectedChat } from '@application/store/conversation/conversationSelectors';
 import { selectAssignableParticipantsByInboxId } from '@application/store/assignable-agent/assignableAgentSelectors';
 import { AudioRecorder } from '../audio-recorder/AudioRecorder';
 import { VoiceRecordButton } from './buttons/VoiceRecordButton';
@@ -89,6 +91,7 @@ const BottomSheetContent = () => {
   const dispatch = useAppDispatch();
   const { bottom } = useSafeAreaInsets();
   const { messageListRef } = useRefsContext();
+  const isSendingRef = useRef(false);
 
   // Selectors
   const userId = useAppSelector(selectUserId);
@@ -281,9 +284,16 @@ const BottomSheetContent = () => {
       //   }
       // });
       // TODO: Add support for multiple files later
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-expect-error
-      messagePayload.file = attachedFiles[0];
+      const asset = attachedFiles[0];
+      if (!asset.uri) {
+        console.warn('ReplyBoxContainer: Attachment missing URI, skipping file attach');
+      } else {
+        messagePayload.file = {
+          uri: asset.uri,
+          fileName: asset.fileName ?? `file_${Date.now()}`,
+          type: asset.type ?? 'application/octet-stream',
+        };
+      }
     }
 
     // TODO: Implement this
@@ -346,14 +356,25 @@ const BottomSheetContent = () => {
   };
 
   const sendMessage = (messagePayload: SendMessagePayload) => {
-    dispatch(conversationActions.sendMessage(messagePayload));
+    if (isSendingRef.current) return;
+    isSendingRef.current = true;
+
+    // Reset UI state BEFORE dispatching to close the race window
+    // where the user can tap send again with the same attachment data
     dispatch(resetSentMessage());
     setSelectedCannedResponse(null);
     dispatch(setMessageContent(''));
     setCCEmails('');
     setBCCEmails('');
     setToEmails('');
-    messageListRef?.current?.scrollToOffset({ offset: 0, animated: true });
+
+    dispatch(conversationActions.sendMessage(messagePayload)).finally(() => {
+      isSendingRef.current = false;
+    });
+
+    requestAnimationFrame(() => {
+      messageListRef?.current?.scrollToEnd({ animated: true });
+    });
   };
 
   const shouldShowFileUpload =

--- a/src/screens/chat-screen/components/reply-box/ReplyBoxContainer.tsx
+++ b/src/screens/chat-screen/components/reply-box/ReplyBoxContainer.tsx
@@ -70,13 +70,9 @@ import {
 } from '@infrastructure/utils/messageVariableUtils';
 import { ReplyEmailHead } from './ReplyEmailHead';
 import { selectAssignableParticipantsByInboxId } from '@application/store/assignable-agent/assignableAgentSelectors';
+import { spring } from '@infrastructure/animation';
 import { AudioRecorder } from '../audio-recorder/AudioRecorder';
 import { VoiceRecordButton } from './buttons/VoiceRecordButton';
-
-const SHEET_APPEAR_SPRING_CONFIG = {
-  damping: 28,
-  stiffness: 200,
-};
 
 // TODO: Implement this
 // const globalConfig = {
@@ -194,9 +190,7 @@ const BottomSheetContent = () => {
   }, [inbox, canReply, dispatch]);
 
   const derivedAddMenuOptionStateValue = useDerivedValue(() => {
-    return isAddMenuOptionSheetOpen
-      ? withSpring(1, SHEET_APPEAR_SPRING_CONFIG)
-      : withSpring(0, SHEET_APPEAR_SPRING_CONFIG);
+    return isAddMenuOptionSheetOpen ? withSpring(1, spring.soft) : withSpring(0, spring.soft);
   });
 
   const animatedInputWrapperStyle = useAnimatedStyle(

--- a/src/screens/chat-screen/components/reply-box/buttons/AddCommandButton.tsx
+++ b/src/screens/chat-screen/components/reply-box/buttons/AddCommandButton.tsx
@@ -25,7 +25,7 @@ export const AddCommandButton = ({
 
   return (
     <Animated.View
-      layout={LinearTransition.springify().damping(20).stiffness(180)}
+      layout={LinearTransition.springify().damping(28).stiffness(200)}
       style={animatedStyle}>
       <Pressable
         {...otherProps}

--- a/src/screens/chat-screen/components/reply-box/buttons/AddCommandButton.tsx
+++ b/src/screens/chat-screen/components/reply-box/buttons/AddCommandButton.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import Animated, { LinearTransition, interpolate, useAnimatedStyle } from 'react-native-reanimated';
+import Animated, { interpolate, useAnimatedStyle } from 'react-native-reanimated';
 import { Pressable } from 'react-native';
 import { Plus } from 'lucide-react-native';
+import { softLayout } from '@infrastructure/animation';
 import { useScaleAnimation } from '@infrastructure/utils';
 import { tailwind, useThemeColors } from '@infrastructure/theme';
 import { AddCommandButtonProps } from '../types';
@@ -24,9 +25,7 @@ export const AddCommandButton = ({
   });
 
   return (
-    <Animated.View
-      layout={LinearTransition.springify().damping(28).stiffness(200)}
-      style={animatedStyle}>
+    <Animated.View layout={softLayout()} style={animatedStyle}>
       <Pressable
         {...otherProps}
         style={({ pressed }) => [tailwind.style(pressed ? 'opacity-70' : '')]}

--- a/src/screens/chat-screen/components/reply-box/buttons/SendMessageButton.tsx
+++ b/src/screens/chat-screen/components/reply-box/buttons/SendMessageButton.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import Animated, { LinearTransition } from 'react-native-reanimated';
+import Animated from 'react-native-reanimated';
 import { Pressable } from 'react-native';
 import { ArrowUp } from 'lucide-react-native';
+import { softLayout } from '@infrastructure/animation';
 import { useScaleAnimation } from '@infrastructure/utils';
 import { tailwind, useThemeColors } from '@infrastructure/theme';
 import { useAppSelector, useThemedStyles } from '@/hooks';
@@ -21,7 +22,7 @@ export const SendMessageButton = (props: SendMessageButtonProps) => {
   return (
     <Pressable {...props} {...handlers}>
       <Animated.View
-        layout={LinearTransition.springify().damping(28).stiffness(200)}
+        layout={softLayout()}
         entering={sendIconEnterAnimation}
         exiting={sendIconExitAnimation}
         style={[tailwind.style('flex items-center justify-center h-10 w-10'), animatedStyle]}>

--- a/src/screens/chat-screen/components/reply-box/buttons/SendMessageButton.tsx
+++ b/src/screens/chat-screen/components/reply-box/buttons/SendMessageButton.tsx
@@ -21,7 +21,7 @@ export const SendMessageButton = (props: SendMessageButtonProps) => {
   return (
     <Pressable {...props} {...handlers}>
       <Animated.View
-        layout={LinearTransition.springify().damping(20).stiffness(180)}
+        layout={LinearTransition.springify().damping(28).stiffness(200)}
         entering={sendIconEnterAnimation}
         exiting={sendIconExitAnimation}
         style={[tailwind.style('flex items-center justify-center h-10 w-10'), animatedStyle]}>

--- a/src/screens/chat-screen/conversation-actions/ConversationActions.tsx
+++ b/src/screens/chat-screen/conversation-actions/ConversationActions.tsx
@@ -40,11 +40,6 @@ export type ConversationActionType = 'mute' | 'status' | 'unmute';
 export const ConversationActions = () => {
   const dispatch = useAppDispatch();
   const themedTailwind = useThemedStyles();
-  const animationConfigs = useBottomSheetSpringConfigs({
-    mass: 1,
-    stiffness: 420,
-    damping: 80,
-  });
   const { updateParticipantSheetRef, actionsModalSheetRef } = useRefsContext();
   const { conversationId } = useChatWindowContext();
   const conversation = useAppSelector(state => selectConversationById(state, conversationId));
@@ -190,7 +185,7 @@ export const ConversationActions = () => {
         handleStyle={tailwind.style('p-0 h-4 pt-[5px]')}
         style={tailwind.style('rounded-[26px] overflow-hidden')}
         backgroundStyle={themedTailwind.style('bg-solid-1')}
-        animationConfigs={animationConfigs}
+        animationConfigs={spring.sheet}
         enablePanDownToClose
         snapPoints={['50%']}>
         <UpdateParticipant activeConversationParticipants={conversationParticipants} />

--- a/src/screens/chat-screen/conversation-actions/ConversationActions.tsx
+++ b/src/screens/chat-screen/conversation-actions/ConversationActions.tsx
@@ -3,7 +3,8 @@ import React from 'react';
 import { Alert, Dimensions, Platform, Share } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import Animated from 'react-native-reanimated';
-import { BottomSheetModal, useBottomSheetSpringConfigs } from '@gorhom/bottom-sheet';
+import { BottomSheetModal } from '@gorhom/bottom-sheet';
+import { spring } from '@infrastructure/animation';
 
 import { BottomSheetBackdrop, Button } from '@infrastructure/ui';
 import {

--- a/src/screens/chat-screen/conversation-actions/ConversationActions.tsx
+++ b/src/screens/chat-screen/conversation-actions/ConversationActions.tsx
@@ -17,13 +17,12 @@ import { TAB_BAR_HEIGHT } from '@domain/constants';
 import { tailwind } from '@infrastructure/theme';
 import { ConversationStatus } from '@domain/types';
 import i18n from '@infrastructure/i18n';
-import { useChatWindowContext } from '@infrastructure/context';
+import { useChatWindowContext, useRefsContext } from '@infrastructure/context';
 import { useAppDispatch, useAppSelector, useThemedStyles } from '@/hooks';
 import { selectConversationById } from '@application/store/conversation/conversationSelectors';
 import { conversationActions } from '@application/store/conversation/conversationActions';
 
 import { setActionState } from '@application/store/conversation/conversationActionSlice';
-import { useRefsContext } from '@infrastructure/context';
 import { selectSingleConversation } from '@application/store/conversation/conversationSelectedSlice';
 // import { teamActions } from '@application/store/team/teamActions';
 // import { selectAllTeams } from '@application/store/team/teamSelectors';
@@ -43,7 +42,7 @@ export const ConversationActions = () => {
   const animationConfigs = useBottomSheetSpringConfigs({
     mass: 1,
     stiffness: 420,
-    damping: 30,
+    damping: 80,
   });
   const { updateParticipantSheetRef, actionsModalSheetRef } = useRefsContext();
   const { conversationId } = useChatWindowContext();

--- a/src/screens/chat-screen/conversation-actions/components/ConversationBasicActions.tsx
+++ b/src/screens/chat-screen/conversation-actions/components/ConversationBasicActions.tsx
@@ -93,9 +93,9 @@ const ConversationActionOption = (props: ConversationActionOptionProps) => {
 
   useEffect(() => {
     if (conversationAction.actionStatus === status) {
-      actionActive.value = withSpring(1);
+      actionActive.value = withSpring(1, { damping: 28, stiffness: 200 });
     } else {
-      actionActive.value = withSpring(0);
+      actionActive.value = withSpring(0, { damping: 28, stiffness: 200 });
     }
   }, [
     actionActive,

--- a/src/screens/chat-screen/conversation-actions/components/ConversationBasicActions.tsx
+++ b/src/screens/chat-screen/conversation-actions/components/ConversationBasicActions.tsx
@@ -7,6 +7,7 @@ import Animated, {
   withSpring,
 } from 'react-native-reanimated';
 
+import { spring } from '@infrastructure/animation';
 import { Icon } from '@infrastructure/ui';
 import { OpenIcon, ResolvedFilledIcon, PendingFilledIcon, SnoozedFilledIcon } from '@/svg-icons';
 import { tailwind } from '@infrastructure/theme';
@@ -93,9 +94,9 @@ const ConversationActionOption = (props: ConversationActionOptionProps) => {
 
   useEffect(() => {
     if (conversationAction.actionStatus === status) {
-      actionActive.value = withSpring(1, { damping: 28, stiffness: 200 });
+      actionActive.value = withSpring(1, spring.soft);
     } else {
-      actionActive.value = withSpring(0, { damping: 28, stiffness: 200 });
+      actionActive.value = withSpring(0, spring.soft);
     }
   }, [
     actionActive,

--- a/src/screens/conversations/ConversationScreen.tsx
+++ b/src/screens/conversations/ConversationScreen.tsx
@@ -286,12 +286,6 @@ const ConversationScreen = () => {
   const themedTailwind = useThemedStyles();
   const dispatch = useAppDispatch();
 
-  const animationConfigs = useBottomSheetSpringConfigs({
-    mass: 1,
-    stiffness: 420,
-    damping: 80,
-  });
-
   const { filtersModalSheetRef } = useRefsContext();
 
   const handleOnDismiss = () => {
@@ -337,7 +331,7 @@ const ConversationScreen = () => {
           handleStyle={tailwind.style('p-0 h-4 pt-[5px]')}
           style={tailwind.style('rounded-[26px] overflow-hidden')}
           backgroundStyle={themedTailwind.style('bg-solid-1')}
-          animationConfigs={animationConfigs}
+          animationConfigs={spring.sheet}
           enablePanDownToClose
           snapPoints={filterSnapPoints}
           onDismiss={handleOnDismiss}>

--- a/src/screens/conversations/ConversationScreen.tsx
+++ b/src/screens/conversations/ConversationScreen.tsx
@@ -38,12 +38,12 @@ import {
   ConversationListStateProvider,
   useConversationListStateContext,
   useRefsContext,
+  useTheme,
 } from '@infrastructure/context';
 
 import { tailwind } from '@infrastructure/theme';
 import { Conversation } from '@domain/types';
 import { useAppDispatch, useAppSelector, useScreenAnalytics, useThemedStyles } from '@/hooks';
-import { useTheme } from '@infrastructure/context';
 import {
   selectBottomSheetState,
   setBottomSheetState,
@@ -267,7 +267,7 @@ const ConversationList = () => {
   ) : (
     <AnimatedFlashList
       refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} />}
-      layout={LinearTransition.springify().damping(18).stiffness(120)}
+      layout={LinearTransition.springify().damping(28).stiffness(200)}
       showsVerticalScrollIndicator={false}
       data={allConversations}
       estimatedItemSize={91}
@@ -275,7 +275,6 @@ const ConversationList = () => {
       onEndReached={handleOnEndReached}
       onEndReachedThreshold={0.5}
       ListFooterComponent={ListFooterComponent}
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       renderItem={handleRender}
       contentContainerStyle={tailwind.style(`pb-[${TAB_BAR_HEIGHT - 1}px]`)}

--- a/src/screens/conversations/ConversationScreen.tsx
+++ b/src/screens/conversations/ConversationScreen.tsx
@@ -290,9 +290,9 @@ const ConversationScreen = () => {
   const dispatch = useAppDispatch();
 
   const animationConfigs = useBottomSheetSpringConfigs({
-    mass: 1.2,
-    stiffness: 300,
-    damping: 50,
+    mass: 1,
+    stiffness: 420,
+    damping: 80,
   });
 
   const { filtersModalSheetRef } = useRefsContext();

--- a/src/screens/conversations/ConversationScreen.tsx
+++ b/src/screens/conversations/ConversationScreen.tsx
@@ -1,14 +1,9 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, AppState, RefreshControl, StatusBar } from 'react-native';
-import Animated, {
-  LinearTransition,
-  runOnJS,
-  SharedValue,
-  useAnimatedScrollHandler,
-} from 'react-native-reanimated';
+import Animated, { runOnJS, SharedValue, useAnimatedScrollHandler } from 'react-native-reanimated';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { BottomSheetModal, useBottomSheetModal } from '@gorhom/bottom-sheet';
-import { spring } from '@infrastructure/animation';
+import { spring, softLayout } from '@infrastructure/animation';
 import { FlashList } from '@shopify/flash-list';
 
 import {
@@ -264,7 +259,7 @@ const ConversationList = () => {
   ) : (
     <AnimatedFlashList
       refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} />}
-      layout={LinearTransition.springify().damping(28).stiffness(200)}
+      layout={softLayout()}
       showsVerticalScrollIndicator={false}
       data={allConversations}
       estimatedItemSize={91}

--- a/src/screens/conversations/ConversationScreen.tsx
+++ b/src/screens/conversations/ConversationScreen.tsx
@@ -7,11 +7,8 @@ import Animated, {
   useAnimatedScrollHandler,
 } from 'react-native-reanimated';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import {
-  BottomSheetModal,
-  useBottomSheetSpringConfigs,
-  useBottomSheetModal,
-} from '@gorhom/bottom-sheet';
+import { BottomSheetModal, useBottomSheetModal } from '@gorhom/bottom-sheet';
+import { spring } from '@infrastructure/animation';
 import { FlashList } from '@shopify/flash-list';
 
 import {

--- a/src/screens/conversations/components/conversation-actions/stories/UpdateAssignee.stories.tsx
+++ b/src/screens/conversations/components/conversation-actions/stories/UpdateAssignee.stories.tsx
@@ -7,8 +7,8 @@ import {
   BottomSheetModal,
   BottomSheetModalProvider,
   BottomSheetScrollView,
-  useBottomSheetSpringConfigs,
 } from '@gorhom/bottom-sheet';
+import { spring } from '@infrastructure/animation';
 
 import { UpdateAssignee } from '../UpdateAssignee';
 import { BottomSheetBackdrop } from '@infrastructure/ui/common/bottomsheet/BottomSheetBackdrop';
@@ -60,12 +60,6 @@ const mockStore = configureStore({
 });
 
 const BaseBottomSheet = ({ children }: { children: React.ReactNode }) => {
-  const animationConfigs = useBottomSheetSpringConfigs({
-    mass: 1,
-    stiffness: 420,
-    damping: 80,
-  });
-
   const { filtersModalSheetRef } = useRefsContext();
 
   useEffect(() => {
@@ -86,7 +80,7 @@ const BaseBottomSheet = ({ children }: { children: React.ReactNode }) => {
               )}
               detached
               enablePanDownToClose
-              animationConfigs={animationConfigs}
+              animationConfigs={spring.sheet}
               handleStyle={tailwind.style('p-0 h-4 pt-[5px]')}
               style={tailwind.style('overflow-hidden')}
               snapPoints={['50%']}>

--- a/src/screens/conversations/components/conversation-actions/stories/UpdateAssignee.stories.tsx
+++ b/src/screens/conversations/components/conversation-actions/stories/UpdateAssignee.stories.tsx
@@ -7,8 +7,8 @@ import {
   BottomSheetModal,
   BottomSheetModalProvider,
   BottomSheetScrollView,
+  useBottomSheetSpringConfigs,
 } from '@gorhom/bottom-sheet';
-import { useBottomSheetSpringConfigs } from '@gorhom/bottom-sheet';
 
 import { UpdateAssignee } from '../UpdateAssignee';
 import { BottomSheetBackdrop } from '@infrastructure/ui/common/bottomsheet/BottomSheetBackdrop';
@@ -63,7 +63,7 @@ const BaseBottomSheet = ({ children }: { children: React.ReactNode }) => {
   const animationConfigs = useBottomSheetSpringConfigs({
     mass: 1,
     stiffness: 420,
-    damping: 30,
+    damping: 80,
   });
 
   const { filtersModalSheetRef } = useRefsContext();

--- a/src/screens/conversations/components/conversation-actions/stories/UpdateLabels.stories.tsx
+++ b/src/screens/conversations/components/conversation-actions/stories/UpdateLabels.stories.tsx
@@ -7,8 +7,8 @@ import {
   BottomSheetModal,
   BottomSheetModalProvider,
   BottomSheetScrollView,
+  useBottomSheetSpringConfigs,
 } from '@gorhom/bottom-sheet';
-import { useBottomSheetSpringConfigs } from '@gorhom/bottom-sheet';
 
 import { UpdateLabels } from '../UpdateLabels';
 
@@ -69,7 +69,7 @@ const BaseBottomSheet = ({ children }: { children: React.ReactNode }) => {
   const animationConfigs = useBottomSheetSpringConfigs({
     mass: 1,
     stiffness: 420,
-    damping: 30,
+    damping: 80,
   });
 
   const { filtersModalSheetRef } = useRefsContext();

--- a/src/screens/conversations/components/conversation-actions/stories/UpdateLabels.stories.tsx
+++ b/src/screens/conversations/components/conversation-actions/stories/UpdateLabels.stories.tsx
@@ -7,8 +7,8 @@ import {
   BottomSheetModal,
   BottomSheetModalProvider,
   BottomSheetScrollView,
-  useBottomSheetSpringConfigs,
 } from '@gorhom/bottom-sheet';
+import { spring } from '@infrastructure/animation';
 
 import { UpdateLabels } from '../UpdateLabels';
 
@@ -66,12 +66,6 @@ const mockStore = configureStore({
 });
 
 const BaseBottomSheet = ({ children }: { children: React.ReactNode }) => {
-  const animationConfigs = useBottomSheetSpringConfigs({
-    mass: 1,
-    stiffness: 420,
-    damping: 80,
-  });
-
   const { filtersModalSheetRef } = useRefsContext();
 
   useEffect(() => {
@@ -92,7 +86,7 @@ const BaseBottomSheet = ({ children }: { children: React.ReactNode }) => {
               )}
               detached
               enablePanDownToClose
-              animationConfigs={animationConfigs}
+              animationConfigs={spring.sheet}
               handleStyle={tailwind.style('p-0 h-4 pt-[5px]')}
               style={tailwind.style('overflow-hidden')}
               snapPoints={['50%']}>

--- a/src/screens/conversations/components/conversation-actions/stories/UpdateStatus.stories.tsx
+++ b/src/screens/conversations/components/conversation-actions/stories/UpdateStatus.stories.tsx
@@ -7,8 +7,8 @@ import {
   BottomSheetModal,
   BottomSheetModalProvider,
   BottomSheetScrollView,
+  useBottomSheetSpringConfigs,
 } from '@gorhom/bottom-sheet';
-import { useBottomSheetSpringConfigs } from '@gorhom/bottom-sheet';
 
 import { UpdateStatus } from '../UpdateStatus';
 import { BottomSheetBackdrop } from '@infrastructure/ui/common/bottomsheet/BottomSheetBackdrop';
@@ -46,7 +46,7 @@ const BaseBottomSheet = ({ children }: { children: React.ReactNode }) => {
   const animationConfigs = useBottomSheetSpringConfigs({
     mass: 1,
     stiffness: 420,
-    damping: 30,
+    damping: 80,
   });
 
   const { filtersModalSheetRef } = useRefsContext();

--- a/src/screens/conversations/components/conversation-actions/stories/UpdateStatus.stories.tsx
+++ b/src/screens/conversations/components/conversation-actions/stories/UpdateStatus.stories.tsx
@@ -7,8 +7,8 @@ import {
   BottomSheetModal,
   BottomSheetModalProvider,
   BottomSheetScrollView,
-  useBottomSheetSpringConfigs,
 } from '@gorhom/bottom-sheet';
+import { spring } from '@infrastructure/animation';
 
 import { UpdateStatus } from '../UpdateStatus';
 import { BottomSheetBackdrop } from '@infrastructure/ui/common/bottomsheet/BottomSheetBackdrop';
@@ -43,12 +43,6 @@ const mockStore = configureStore({
 });
 
 const BaseBottomSheet = ({ children }: { children: React.ReactNode }) => {
-  const animationConfigs = useBottomSheetSpringConfigs({
-    mass: 1,
-    stiffness: 420,
-    damping: 80,
-  });
-
   const { filtersModalSheetRef } = useRefsContext();
   useEffect(() => {
     filtersModalSheetRef.current?.present();
@@ -68,7 +62,7 @@ const BaseBottomSheet = ({ children }: { children: React.ReactNode }) => {
               )}
               detached
               enablePanDownToClose
-              animationConfigs={animationConfigs}
+              animationConfigs={spring.sheet}
               handleStyle={tailwind.style('p-0 h-4 pt-[5px]')}
               style={tailwind.style('overflow-hidden')}
               snapPoints={['50%']}>

--- a/src/screens/conversations/components/conversation-filters/stories/AssigneeTypeFilters.stories.tsx
+++ b/src/screens/conversations/components/conversation-filters/stories/AssigneeTypeFilters.stories.tsx
@@ -7,8 +7,8 @@ import {
   BottomSheetModal,
   BottomSheetModalProvider,
   BottomSheetScrollView,
+  useBottomSheetSpringConfigs,
 } from '@gorhom/bottom-sheet';
-import { useBottomSheetSpringConfigs } from '@gorhom/bottom-sheet';
 
 import { AssigneeTypeFilters } from '../AssigneeTypeFilters';
 import { defaultFilterState } from '@application/store/conversation/conversationFilterSlice';
@@ -43,7 +43,7 @@ const BaseBottomSheet = ({ children }: { children: React.ReactNode }) => {
   const animationConfigs = useBottomSheetSpringConfigs({
     mass: 1,
     stiffness: 420,
-    damping: 30,
+    damping: 80,
   });
 
   const { filtersModalSheetRef } = useRefsContext();

--- a/src/screens/conversations/components/conversation-filters/stories/AssigneeTypeFilters.stories.tsx
+++ b/src/screens/conversations/components/conversation-filters/stories/AssigneeTypeFilters.stories.tsx
@@ -7,8 +7,8 @@ import {
   BottomSheetModal,
   BottomSheetModalProvider,
   BottomSheetScrollView,
-  useBottomSheetSpringConfigs,
 } from '@gorhom/bottom-sheet';
+import { spring } from '@infrastructure/animation';
 
 import { AssigneeTypeFilters } from '../AssigneeTypeFilters';
 import { defaultFilterState } from '@application/store/conversation/conversationFilterSlice';
@@ -40,12 +40,6 @@ const mockStore = configureStore({
 });
 
 const BaseBottomSheet = ({ children }: { children: React.ReactNode }) => {
-  const animationConfigs = useBottomSheetSpringConfigs({
-    mass: 1,
-    stiffness: 420,
-    damping: 80,
-  });
-
   const { filtersModalSheetRef } = useRefsContext();
 
   useEffect(() => {
@@ -66,7 +60,7 @@ const BaseBottomSheet = ({ children }: { children: React.ReactNode }) => {
               )}
               detached
               enablePanDownToClose
-              animationConfigs={animationConfigs}
+              animationConfigs={spring.sheet}
               handleStyle={tailwind.style('p-0 h-4 pt-[5px]')}
               style={tailwind.style('overflow-hidden')}
               snapPoints={['50%']}>

--- a/src/screens/conversations/components/conversation-filters/stories/SortByFilters.stories.tsx
+++ b/src/screens/conversations/components/conversation-filters/stories/SortByFilters.stories.tsx
@@ -7,8 +7,8 @@ import {
   BottomSheetModal,
   BottomSheetModalProvider,
   BottomSheetScrollView,
-  useBottomSheetSpringConfigs,
 } from '@gorhom/bottom-sheet';
+import { spring } from '@infrastructure/animation';
 
 import { SortByFilters } from '../SortByFilters';
 import { defaultFilterState } from '@application/store/conversation/conversationFilterSlice';
@@ -40,12 +40,6 @@ const mockStore = configureStore({
 });
 
 const BaseBottomSheet = ({ children }: { children: React.ReactNode }) => {
-  const animationConfigs = useBottomSheetSpringConfigs({
-    mass: 1,
-    stiffness: 420,
-    damping: 80,
-  });
-
   const { filtersModalSheetRef } = useRefsContext();
 
   useEffect(() => {
@@ -66,7 +60,7 @@ const BaseBottomSheet = ({ children }: { children: React.ReactNode }) => {
               )}
               detached
               enablePanDownToClose
-              animationConfigs={animationConfigs}
+              animationConfigs={spring.sheet}
               handleStyle={tailwind.style('p-0 h-4 pt-[5px]')}
               style={tailwind.style('overflow-hidden')}
               snapPoints={['50%']}>

--- a/src/screens/conversations/components/conversation-filters/stories/SortByFilters.stories.tsx
+++ b/src/screens/conversations/components/conversation-filters/stories/SortByFilters.stories.tsx
@@ -7,8 +7,8 @@ import {
   BottomSheetModal,
   BottomSheetModalProvider,
   BottomSheetScrollView,
+  useBottomSheetSpringConfigs,
 } from '@gorhom/bottom-sheet';
-import { useBottomSheetSpringConfigs } from '@gorhom/bottom-sheet';
 
 import { SortByFilters } from '../SortByFilters';
 import { defaultFilterState } from '@application/store/conversation/conversationFilterSlice';
@@ -43,7 +43,7 @@ const BaseBottomSheet = ({ children }: { children: React.ReactNode }) => {
   const animationConfigs = useBottomSheetSpringConfigs({
     mass: 1,
     stiffness: 420,
-    damping: 30,
+    damping: 80,
   });
 
   const { filtersModalSheetRef } = useRefsContext();

--- a/src/screens/conversations/components/conversation-filters/stories/StatusFilters.stories.tsx
+++ b/src/screens/conversations/components/conversation-filters/stories/StatusFilters.stories.tsx
@@ -7,8 +7,8 @@ import {
   BottomSheetModal,
   BottomSheetModalProvider,
   BottomSheetScrollView,
-  useBottomSheetSpringConfigs,
 } from '@gorhom/bottom-sheet';
+import { spring } from '@infrastructure/animation';
 
 import { StatusFilters } from '../StatusFilters';
 import { defaultFilterState } from '@application/store/conversation/conversationFilterSlice';
@@ -41,12 +41,6 @@ const mockStore = configureStore({
 });
 
 const BaseBottomSheet = ({ children }: { children: React.ReactNode }) => {
-  const animationConfigs = useBottomSheetSpringConfigs({
-    mass: 1,
-    stiffness: 420,
-    damping: 80,
-  });
-
   const { filtersModalSheetRef } = useRefsContext();
 
   useEffect(() => {
@@ -67,7 +61,7 @@ const BaseBottomSheet = ({ children }: { children: React.ReactNode }) => {
               )}
               detached
               enablePanDownToClose
-              animationConfigs={animationConfigs}
+              animationConfigs={spring.sheet}
               handleStyle={tailwind.style('p-0 h-4 pt-[5px]')}
               style={tailwind.style('overflow-hidden')}
               snapPoints={['50%']}>

--- a/src/screens/conversations/components/conversation-filters/stories/StatusFilters.stories.tsx
+++ b/src/screens/conversations/components/conversation-filters/stories/StatusFilters.stories.tsx
@@ -7,8 +7,8 @@ import {
   BottomSheetModal,
   BottomSheetModalProvider,
   BottomSheetScrollView,
+  useBottomSheetSpringConfigs,
 } from '@gorhom/bottom-sheet';
-import { useBottomSheetSpringConfigs } from '@gorhom/bottom-sheet';
 
 import { StatusFilters } from '../StatusFilters';
 import { defaultFilterState } from '@application/store/conversation/conversationFilterSlice';
@@ -44,7 +44,7 @@ const BaseBottomSheet = ({ children }: { children: React.ReactNode }) => {
   const animationConfigs = useBottomSheetSpringConfigs({
     mass: 1,
     stiffness: 420,
-    damping: 30,
+    damping: 80,
   });
 
   const { filtersModalSheetRef } = useRefsContext();

--- a/src/screens/conversations/components/conversation-header/ConversationHeaderContainer.tsx
+++ b/src/screens/conversations/components/conversation-header/ConversationHeaderContainer.tsx
@@ -6,6 +6,7 @@ import Animated, {
   withSpring,
 } from 'react-native-reanimated';
 
+import { spring } from '@infrastructure/animation';
 import { useConversationListStateContext } from '@infrastructure/context';
 import { tailwind } from '@infrastructure/theme';
 import { useHaptic } from '@infrastructure/utils';
@@ -71,8 +72,8 @@ export const ConversationHeader = () => {
 
   const headerOpenState = useDerivedValue(() =>
     currentState !== 'none' && currentState !== 'Select'
-      ? withSpring(1, { damping: 28, stiffness: 200 })
-      : withSpring(0, { damping: 28, stiffness: 200 }),
+      ? withSpring(1, spring.soft)
+      : withSpring(0, spring.soft),
   );
 
   // This creates a subtle visual effect where the border fades away when the header is in an active state (Search/Filter) and reappears when returning to the default state.

--- a/src/screens/conversations/components/conversation-header/ConversationHeaderContainer.tsx
+++ b/src/screens/conversations/components/conversation-header/ConversationHeaderContainer.tsx
@@ -10,7 +10,7 @@ import { useConversationListStateContext } from '@infrastructure/context';
 import { tailwind } from '@infrastructure/theme';
 import { useHaptic } from '@infrastructure/utils';
 import { getFilteredConversations } from '@application/store/conversation/conversationSelectors';
-import { useThemedStyles } from '@/hooks';
+import { useThemedStyles, useAppDispatch, useAppSelector } from '@/hooks';
 import { selectUserId } from '@application/store/auth/authSelectors';
 import {
   resetFilters,
@@ -30,7 +30,6 @@ import {
 import { ConversationFilterBar } from '../conversation-filters';
 import { ConversationHeaderPresenter } from './ConversationHeaderPresenter';
 
-import { useAppDispatch, useAppSelector } from '@/hooks';
 import AnalyticsHelper from '@infrastructure/utils/analyticsUtils';
 import { CONVERSATION_EVENTS } from '@domain/constants/analyticsEvents';
 
@@ -71,7 +70,9 @@ export const ConversationHeader = () => {
   const headerBorderColor = tailwind.color('text-slate-6') as string;
 
   const headerOpenState = useDerivedValue(() =>
-    currentState !== 'none' && currentState !== 'Select' ? withSpring(1) : withSpring(0),
+    currentState !== 'none' && currentState !== 'Select'
+      ? withSpring(1, { damping: 28, stiffness: 200 })
+      : withSpring(0, { damping: 28, stiffness: 200 }),
   );
 
   // This creates a subtle visual effect where the border fades away when the header is in an active state (Search/Filter) and reappears when returning to the default state.

--- a/src/screens/conversations/components/conversation-item/ConversationAvatar.tsx
+++ b/src/screens/conversations/components/conversation-item/ConversationAvatar.tsx
@@ -1,6 +1,6 @@
 import React, { memo } from 'react';
 import { ImageURISource } from 'react-native';
-import { LinearTransition } from 'react-native-reanimated';
+import { softLayout } from '@infrastructure/animation';
 import isEqual from 'lodash/isEqual';
 
 import { Avatar, AvatarStatusType } from '@infrastructure/ui/common';
@@ -21,7 +21,7 @@ const checkIfPropsAreSame = (prev: ConversationAvatarProps, next: ConversationAv
 export const ConversationAvatar = memo((props: ConversationAvatarProps) => {
   const { src, name, status } = props;
   return (
-    <AnimatedNativeView layout={LinearTransition.springify().damping(28).stiffness(200)}>
+    <AnimatedNativeView layout={softLayout()}>
       <Avatar
         size="2xl"
         src={src}

--- a/src/screens/conversations/components/conversation-item/ConversationItemDetail.tsx
+++ b/src/screens/conversations/components/conversation-item/ConversationItemDetail.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/display-name */
 import React, { memo, useState } from 'react';
 import { Dimensions, Text } from 'react-native';
-import { LinearTransition } from 'react-native-reanimated';
+import { softLayout } from '@infrastructure/animation';
 import isEqual from 'lodash/isEqual';
 
 import { AnimatedNativeView, NativeView } from '@infrastructure/ui/native-components';
@@ -118,7 +118,7 @@ export const ConversationItemDetail = memo((props: ConversationDetailSubCellProp
 
   return (
     <AnimatedNativeView
-      layout={LinearTransition.springify().damping(28).stiffness(200)}
+      layout={softLayout()}
       style={themedTailwind.style('flex-1 py-3 border-b border-b-slate-3')}>
       {/* Row 0: Inbox indicator */}
       {hasInboxIndicator && (

--- a/src/screens/conversations/components/conversation-item/ConversationSelect.tsx
+++ b/src/screens/conversations/components/conversation-item/ConversationSelect.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/display-name */
 import React, { memo } from 'react';
-import { LinearTransition } from 'react-native-reanimated';
+import { softLayout } from '@infrastructure/animation';
 
 import { Icon } from '@infrastructure/ui/common';
 import { AnimatedNativeView } from '@infrastructure/ui/native-components';
@@ -16,9 +16,7 @@ export const ConversationSelect = memo((props: ConversationSelectProps) => {
   const { isSelected, currentState } = props;
 
   return currentState === 'Select' ? (
-    <AnimatedNativeView
-      layout={LinearTransition.springify().damping(28).stiffness(200)}
-      style={tailwind.style('h-full pt-[23px] pr-3')}>
+    <AnimatedNativeView layout={softLayout()} style={tailwind.style('h-full pt-[23px] pr-3')}>
       <Icon icon={isSelected ? <CheckedIcon /> : <UncheckedIcon />} size={20} />
     </AnimatedNativeView>
   ) : null;

--- a/src/screens/inbox/InboxScreen.tsx
+++ b/src/screens/inbox/InboxScreen.tsx
@@ -1,14 +1,10 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { ActivityIndicator, RefreshControl, StatusBar } from 'react-native';
-import Animated, {
-  LinearTransition,
-  runOnJS,
-  SharedValue,
-  useAnimatedScrollHandler,
-} from 'react-native-reanimated';
+import Animated, { runOnJS, SharedValue, useAnimatedScrollHandler } from 'react-native-reanimated';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { FlashList, ListRenderItem } from '@shopify/flash-list';
 
+import { softLayout } from '@infrastructure/animation';
 import { SCREENS, TAB_BAR_HEIGHT } from '@domain/constants';
 import {
   InboxListStateProvider,
@@ -157,7 +153,7 @@ const InboxList = () => {
   ) : (
     <AnimatedFlashlist
       refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} />}
-      layout={LinearTransition.springify().damping(28).stiffness(200)}
+      layout={softLayout()}
       showsVerticalScrollIndicator={false}
       data={notifications}
       onScroll={scrollHandler}

--- a/src/screens/inbox/InboxScreen.tsx
+++ b/src/screens/inbox/InboxScreen.tsx
@@ -10,7 +10,11 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { FlashList, ListRenderItem } from '@shopify/flash-list';
 
 import { SCREENS, TAB_BAR_HEIGHT } from '@domain/constants';
-import { InboxListStateProvider, useTheme } from '@infrastructure/context';
+import {
+  InboxListStateProvider,
+  useTheme,
+  useInboxListStateContext,
+} from '@infrastructure/context';
 import type { Notification } from '@domain/types/Notification';
 import { tailwind } from '@infrastructure/theme';
 import { useAppDispatch, useAppSelector, useScreenAnalytics, useThemedStyles } from '@/hooks';
@@ -21,7 +25,6 @@ import {
   getFilteredNotifications,
 } from '@application/store/notification/notificationSelectors';
 import { InboxHeader, InboxItemContainer } from './components';
-import { useInboxListStateContext } from '@infrastructure/context';
 import { resetNotifications } from '@application/store/notification/notificationSlice';
 import { showToast } from '@infrastructure/utils/toastUtils';
 import i18n from '@infrastructure/i18n';
@@ -154,7 +157,7 @@ const InboxList = () => {
   ) : (
     <AnimatedFlashlist
       refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} />}
-      layout={LinearTransition.springify().damping(18).stiffness(120)}
+      layout={LinearTransition.springify().damping(28).stiffness(200)}
       showsVerticalScrollIndicator={false}
       data={notifications}
       onScroll={scrollHandler}

--- a/src/screens/inbox/components/InboxHeader.tsx
+++ b/src/screens/inbox/components/InboxHeader.tsx
@@ -26,7 +26,7 @@ export const InboxHeader = (props: InboxHeaderProps) => {
   const animationConfigs = useBottomSheetSpringConfigs({
     mass: 1,
     stiffness: 420,
-    damping: 30,
+    damping: 80,
   });
 
   return (

--- a/src/screens/inbox/components/InboxHeader.tsx
+++ b/src/screens/inbox/components/InboxHeader.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { Pressable } from 'react-native';
 import Animated from 'react-native-reanimated';
-import { BottomSheetModal, useBottomSheetSpringConfigs } from '@gorhom/bottom-sheet';
+import { BottomSheetModal } from '@gorhom/bottom-sheet';
+import { spring } from '@infrastructure/animation';
 
 import { BottomSheetBackdrop, BottomSheetWrapper } from '@infrastructure/ui';
 
@@ -22,12 +23,6 @@ export const InboxHeader = (props: InboxHeaderProps) => {
   const handleToggleState = () => {
     inboxFiltersSheetRef.current?.present();
   };
-
-  const animationConfigs = useBottomSheetSpringConfigs({
-    mass: 1,
-    stiffness: 420,
-    damping: 80,
-  });
 
   return (
     <Animated.View style={[tailwind.style('border-b-[1px] border-b-slate-6')]}>
@@ -58,7 +53,7 @@ export const InboxHeader = (props: InboxHeaderProps) => {
         handleIndicatorStyle={tailwind.style('overflow-hidden bg-blackA-A6 w-8 h-1 rounded-[11px]')}
         handleStyle={tailwind.style('p-0 h-4 pt-[5px]')}
         style={tailwind.style('rounded-[26px] overflow-hidden')}
-        animationConfigs={animationConfigs}
+        animationConfigs={spring.sheet}
         enablePanDownToClose
         snapPoints={[160]}>
         <BottomSheetWrapper>

--- a/src/screens/settings/SettingsScreen.tsx
+++ b/src/screens/settings/SettingsScreen.tsx
@@ -144,12 +144,6 @@ const SettingsScreen = () => {
   const { colors } = useThemeColors();
   const hapticSelection = useHaptic();
 
-  const animationConfigs = useBottomSheetSpringConfigs({
-    mass: 1,
-    stiffness: 420,
-    damping: 80,
-  });
-
   const openSheet = () => {
     hapticSelection?.();
     userAvailabilityStatusSheetRef.current?.present();
@@ -366,7 +360,7 @@ const SettingsScreen = () => {
         backdropComponent={BottomSheetBackdrop}
         handleIndicatorStyle={tailwind.style('overflow-hidden bg-blackA-A6 w-8 h-1 rounded-[11px]')}
         enablePanDownToClose
-        animationConfigs={animationConfigs}
+        animationConfigs={spring.sheet}
         // TODO: Fix this later
         // bottomInset={bottom === 0 ? 12 : bottom}
         handleStyle={tailwind.style('p-0 h-4 pt-[5px]')}
@@ -388,7 +382,7 @@ const SettingsScreen = () => {
         // TODO: Fix this later
         // bottomInset={bottom === 0 ? 12 : bottom}
         enablePanDownToClose
-        animationConfigs={animationConfigs}
+        animationConfigs={spring.sheet}
         handleStyle={tailwind.style('p-0 h-4 pt-[5px]')}
         style={tailwind.style('rounded-[26px] overflow-hidden')}
         backgroundStyle={themedTailwind.style('bg-solid-1')}
@@ -405,7 +399,7 @@ const SettingsScreen = () => {
         // TODO: Fix this later
         // bottomInset={bottom === 0 ? 12 : bottom}
         enablePanDownToClose
-        animationConfigs={animationConfigs}
+        animationConfigs={spring.sheet}
         handleStyle={tailwind.style('p-0 h-4 pt-[5px]')}
         style={tailwind.style('rounded-[26px] overflow-hidden')}
         backgroundStyle={themedTailwind.style('bg-solid-1')}
@@ -422,7 +416,7 @@ const SettingsScreen = () => {
         // TODO: Fix this later
         // bottomInset={bottom === 0 ? 12 : bottom}
         enablePanDownToClose
-        animationConfigs={animationConfigs}
+        animationConfigs={spring.sheet}
         handleStyle={tailwind.style('p-0 h-4 pt-[5px]')}
         style={tailwind.style('rounded-[26px] overflow-hidden')}
         backgroundStyle={themedTailwind.style('bg-solid-1')}
@@ -441,7 +435,7 @@ const SettingsScreen = () => {
         backdropComponent={BottomSheetBackdrop}
         handleIndicatorStyle={tailwind.style('overflow-hidden bg-blackA-A6 w-8 h-1 rounded-[11px]')}
         enablePanDownToClose
-        animationConfigs={animationConfigs}
+        animationConfigs={spring.sheet}
         handleStyle={tailwind.style('p-0 h-4 pt-[5px]')}
         style={tailwind.style('rounded-[26px] overflow-hidden')}
         backgroundStyle={themedTailwind.style('bg-solid-1')}

--- a/src/screens/settings/SettingsScreen.tsx
+++ b/src/screens/settings/SettingsScreen.tsx
@@ -15,14 +15,14 @@ import * as Device from 'expo-device';
 import ChatWootWidget from '@chatwoot/react-native-widget';
 import { useSelector } from 'react-redux';
 import * as Application from 'expo-application';
-import { Account, AvailabilityStatus } from '@domain/types';
+import { Account, AvailabilityStatus, GenericListType } from '@domain/types';
 import { clearAllConversations } from '@application/store/conversation/conversationSlice';
 import { resetNotifications } from '@application/store/notification/notificationSlice';
 import { clearAllContacts } from '@application/store/contact/contactSlice';
 
 import i18n from '@infrastructure/i18n';
 import { tailwind, useThemeColors } from '@infrastructure/theme';
-import { useThemedStyles } from '@/hooks';
+import { useThemedStyles, useAppDispatch, useAppSelector, useScreenAnalytics } from '@/hooks';
 
 import {
   BottomSheetBackdrop,
@@ -41,7 +41,6 @@ import { BuildInfo } from '@infrastructure/ui/common';
 import { LANGUAGES, SCREENS, TAB_BAR_HEIGHT } from '@domain/constants';
 import { useRefsContext, useTheme } from '@infrastructure/context';
 import { NotificationIcon, SwitchIcon, TranslateIcon, ThemeIcon } from '@/svg-icons';
-import { GenericListType } from '@domain/types';
 
 import { useHaptic } from '@infrastructure/utils';
 import { SettingsHeader } from './SettingsHeader';
@@ -65,7 +64,6 @@ import AnalyticsHelper from '@infrastructure/utils/analyticsUtils';
 import { PROFILE_EVENTS, ACCOUNT_EVENTS } from '@domain/constants/analyticsEvents';
 import { getUserPermissions } from '@infrastructure/utils/permissionUtils';
 import { CONVERSATION_PERMISSIONS } from '@domain/constants/permissions';
-import { useAppDispatch, useAppSelector, useScreenAnalytics } from '@/hooks';
 
 const appName = Application.applicationName;
 const appVersion = Application.nativeApplicationVersion;
@@ -152,7 +150,7 @@ const SettingsScreen = () => {
   const animationConfigs = useBottomSheetSpringConfigs({
     mass: 1,
     stiffness: 420,
-    damping: 30,
+    damping: 80,
   });
 
   const openSheet = () => {

--- a/src/screens/settings/SettingsScreen.tsx
+++ b/src/screens/settings/SettingsScreen.tsx
@@ -6,11 +6,8 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { StackActions, useNavigation } from '@react-navigation/native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
-import {
-  BottomSheetModal,
-  BottomSheetScrollView,
-  useBottomSheetSpringConfigs,
-} from '@gorhom/bottom-sheet';
+import { BottomSheetModal, BottomSheetScrollView } from '@gorhom/bottom-sheet';
+import { spring } from '@infrastructure/animation';
 import * as Device from 'expo-device';
 import ChatWootWidget from '@chatwoot/react-native-widget';
 import { useSelector } from 'react-redux';


### PR DESCRIPTION
## Issue
Multiple UX bugs identified in the first TestFlight build (4.1.0, build 29) after the Expo SDK 55 migration, plus excessive bounce/overshoot in animations throughout the app.

## Fix
Resolved all P0/P1/P2 QA issues and implemented a centralized animation token system to eliminate hardcoded spring/timing values across ~55 files.

## Root Cause
- **Duplicate sending**: Missing send-in-progress guard + numeric ID dedup
- **Camera roll upload**: Wrong Content-Type header + PickedAsset mapping
- **Scroll pinning**: FlashList v2.0.2 `startRenderingFromBottom` fundamentally broken; migrated to v2.3.0 `inverted`
- **HEIC uploads**: iOS camera produces HEIC that server-side didn't handle; added client-side HEIC→JPEG conversion
- **Firebase errors**: Unguarded `getApp()` calls in simulator where Firebase isn't initialized
- **Bounce animations**: Underdamped springs (damping: 30) and missing `.springify()` on layout animation builders
- **Animation tech debt**: 50+ files with identical hardcoded spring/timing values scattered throughout

## Changes

### P0 Fixes
- Duplicate message sending prevention (isSendingRef + numeric ID dedup)
- Camera roll image upload (Content-Type + PickedAsset mapping)
- Scroll pinning (FlashList v2.3.0 inverted migration)

### P1/P2 Fixes
- Activity message pill styling
- Timestamp grouping on last message
- Avatar on last message
- Dark mode footer contrast
- Header height
- Android footer safe area insets
- Firebase simulator error silencing

### HEIC Image Handling
- Client-side HEIC→JPEG conversion via `processImageForUpload()`
- SDK 55 API migration (`ImageManipulator.manipulate()` context API, `File` class)
- `rotate(0)` EXIF orientation fix for iOS
- GIF passthrough, skip JPEG re-encode, extension mismatch fix

### Animation System (new)
- Created `src/infrastructure/animation/` token module:
  - `springs.ts` — 9 spring tokens + 5 timing presets
  - `animations.ts` — 16 factory functions (layout transitions, slide animations, fades)
  - `index.ts` — barrel exports
  - Unit tests for tokens and factory fresh-instance behavior
- Eliminated bounce across 20+ components (standardized spring damping)
- Eliminated container bounce in bottom sheets (damping 30→80) and slide animations
- Migrated all 19 `useBottomSheetSpringConfigs` call sites → `spring.sheet` token
- Migrated all `withSpring` inline configs → `spring.soft` token
- Migrated all `LinearTransition.springify()` chains → `softLayout()`/`snappyLayout()` factories
- Migrated all `SlideInDown/Out.springify()` chains → factory calls
- Migrated tab bar, swipeable, keyboard animations → named spring tokens
- Migrated all `FadeIn/Out.duration(N)` → fade factory functions
- Fixed AudioRecorder missing `.springify()` bug
- Removed dead code and stale commented-out blocks

## Affected Areas
- [x] Components (~55 files)
- [x] Screens
- [x] Redux State
- [ ] Navigation
- [x] Utils/Types
- [x] Infrastructure (animation module, theme, hooks)
- [x] Tests (18 new animation tests, updated test mocks)

## Verification
- iOS: Open app → test all bottom sheets (settings, filters, message menu) → verify smooth open/close with minimal bounce
- iOS: Send messages → verify no duplicates, scroll stays pinned
- iOS: Upload HEIC photo from camera roll → verify it uploads as JPEG
- iOS: Trigger audio recorder → verify slide-in/out animation is smooth
- iOS: Switch tabs → verify tab bar transitions are clean
- iOS: Swipe conversation rows → verify swipeable animations

## Test Results
- 86 test suites, 1364 tests passing
- Zero lint errors
- 18 new animation token/factory tests

## Related
- QA Report: `docs/temp/mobile-ux-testing/qa-report-2026-03-08-sdk55-testflight.md`
- Server PR: https://github.com/eleva-labs/chatwoot/pull/128 (merged)

Generated with [Claude Code](https://claude.com/claude-code)